### PR TITLE
Change group to io.micronaut.configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ ext {
 subprojects { Project subproject ->
 
     version project.projectVersion
-	group "io.micronaut.gcp"
+	group "io.micronaut.configuration"
     ext {
         isConfiguration = subproject.projectDir.parentFile.name == 'configurations'
         isBuildSnapshot = version.toString().endsWith("-SNAPSHOT")


### PR DESCRIPTION
Should the group not be `io.micronaut.configuration`?