### PR TITLE
Updating and fixing README for function example

### DIFF
--- a/examples/hello-world-cloud-function/README.md
+++ b/examples/hello-world-cloud-function/README.md
@@ -29,7 +29,7 @@ $ cd build/libs
 To deploy the function make sure you have `gcloud` CLI then run:
 
 ```bash
-$ gcloud beta functions deploy myfunction --entry-point io.micronaut.gcp.function.http.HttpFunction --runtime java11 --trigger-http
+$ gcloud functions deploy myfunction --entry-point io.micronaut.gcp.function.http.HttpFunction --runtime java11 --trigger-http
 ```
 
 The `myfunction` bit can be changed to whatever you want to name your function.
@@ -39,11 +39,11 @@ Choose unauthenticated access if you don't need auth.
 To obtain the trigger URL do the following:
 
 ```bash
-$ YOUR_HTTP_TRIGGER_URL=$(gcloud beta functions describe myfunction --format='value(httpsTrigger.url)') 
+$ YOUR_HTTP_TRIGGER_URL=$(gcloud functions describe myfunction --format='value(httpsTrigger.url)') 
 ```
 
 You can then use this variable to test the function invocation:
 
 ```bash
-$ curl -i $YOUR_HTTP_TRIGGER_URL/hello/John
+$ curl -i $YOUR_HTTP_TRIGGER_URL/pets
 ```


### PR DESCRIPTION
- gcloud functions no longer beta
- changing /hello endpoint in curl to proper endpoint.