### PR TITLE
Fixes GH-219

### DIFF
--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/annotation/Subscription.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/annotation/Subscription.java
@@ -38,10 +38,10 @@ public @interface Subscription {
 
     /**
      * Defines the Content-Type to be used for message deserialization.
-     * There's no default, if not set and the message does not contain a Content-Type header deserialization will fail.
+     * Defaults to application/json.
      * @return contentType to use
      */
-    String contentType() default "";
+    String contentType() default "application/json";
 
     /**
      * Defines the name of a particular configuration used for a Subscriber.

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/bind/PubSubBodyBinder.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/bind/PubSubBodyBinder.java
@@ -18,6 +18,7 @@ package io.micronaut.gcp.pubsub.bind;
 import com.google.pubsub.v1.PubsubMessage;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.gcp.pubsub.exception.PubSubListenerException;
 import io.micronaut.gcp.pubsub.serdes.PubSubMessageSerDes;
 import io.micronaut.gcp.pubsub.serdes.PubSubMessageSerDesRegistry;
@@ -56,7 +57,7 @@ public class PubSubBodyBinder implements PubSubAnnotatedArgumentBinder<Body> {
         } else if (bodyType.getType().equals(PubsubMessage.class)) {
             result = state.getPubsubMessage();
         } else {
-            if (!state.getPubsubMessage().containsAttributes("Content-Type")) {
+            if (StringUtils.isEmpty(state.getContentType()) && !state.getPubsubMessage().containsAttributes("Content-Type")) {
                 throw  new PubSubListenerException("Could not detect Content-Type header at message and no Content-Type specified on method.");
             }
             PubSubMessageSerDes serDes = serDesRegistry.find(state.getContentType())


### PR DESCRIPTION
- Default contentType is now application/json. Messages without a contentType will have it set by default (same as docs)
- Fixed issue where manual ack was being verified on the wrong place, causing an warning to be displayed when not needed