### PR TITLE
Migrate compute instance metadata code from core

### DIFF
--- a/gcp-common/build.gradle
+++ b/gcp-common/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java"
     annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:$micronautDocsVersion"
 
-    compileOnly "io.micronaut:micronaut-inject-java" // needed only for IntelliJ
+    compileOnly "io.micronaut:micronaut-runtime"
     api "io.micronaut:micronaut-inject:$micronautVersion"
     api 'com.google.auth:google-auth-library-oauth2-http:0.21.1'
     api 'com.google.cloud:google-cloud-core:1.93.8'

--- a/gcp-common/src/main/java/io/micronaut/discovery/cloud/gcp/GoogleComputeInstanceMetadata.java
+++ b/gcp-common/src/main/java/io/micronaut/discovery/cloud/gcp/GoogleComputeInstanceMetadata.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.cloud.gcp;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.micronaut.context.env.ComputePlatform;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.discovery.cloud.AbstractComputeInstanceMetadata;
+
+/**
+ * Represents {@link io.micronaut.discovery.cloud.ComputeInstanceMetadata} for Google Cloud Platform.
+ *
+ * @author rvanderwerf
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+@Introspected
+public class GoogleComputeInstanceMetadata extends AbstractComputeInstanceMetadata {
+
+    private final ComputePlatform computePlatform = ComputePlatform.GOOGLE_COMPUTE;
+
+    @Override
+    @JsonIgnore
+    public ComputePlatform getComputePlatform() {
+        return computePlatform;
+    }
+
+    @Override
+    public String getRegion() {
+        if (availabilityZone != null) {
+            return availabilityZone.substring(0, availabilityZone.length() - 2);
+        }
+        return region;
+    }
+
+}

--- a/gcp-common/src/main/java/io/micronaut/discovery/cloud/gcp/GoogleComputeInstanceMetadataResolver.java
+++ b/gcp-common/src/main/java/io/micronaut/discovery/cloud/gcp/GoogleComputeInstanceMetadataResolver.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.cloud.gcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.discovery.cloud.ComputeInstanceMetadata;
+import io.micronaut.discovery.cloud.ComputeInstanceMetadataResolver;
+import io.micronaut.discovery.cloud.NetworkInterface;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.micronaut.discovery.cloud.ComputeInstanceMetadataResolverUtils.*;
+
+/**
+ * Resolves {@link ComputeInstanceMetadata} for Google Cloud Platform.
+ *
+ * @author rvanderwerf
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+@Singleton
+@Requires(env = Environment.GOOGLE_COMPUTE)
+@Requires(property = GoogleComputeMetadataConfiguration.PREFIX + ".enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+@Primary
+public class GoogleComputeInstanceMetadataResolver implements ComputeInstanceMetadataResolver {
+
+    /**
+     * Constant for Metadata flavor.
+     */
+    public static final String HEADER_METADATA_FLAVOR = "Metadata-Flavor";
+
+    private static final Logger LOG = LoggerFactory.getLogger(GoogleComputeInstanceMetadataResolver.class);
+
+    private final ObjectMapper objectMapper;
+    private final GoogleComputeMetadataConfiguration configuration;
+    private GoogleComputeInstanceMetadata cachedMetadata;
+
+    /**
+     *
+     * @param objectMapper To read and write JSON
+     * @param configuration The configuration for computing Google Metadata
+     */
+    @Inject
+    public GoogleComputeInstanceMetadataResolver(ObjectMapper objectMapper, GoogleComputeMetadataConfiguration configuration) {
+        this.objectMapper = objectMapper;
+        this.configuration = configuration;
+    }
+
+    /**
+     * Construct with default settings.
+     */
+    public GoogleComputeInstanceMetadataResolver() {
+        this.objectMapper = new ObjectMapper();
+        this.configuration = new GoogleComputeMetadataConfiguration();
+    }
+
+    @Override
+    public Optional<ComputeInstanceMetadata> resolve(Environment environment) {
+        if (!configuration.isEnabled()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Resolving of Google Compute Instance metadata is disabled");
+            }
+            return Optional.empty();
+        }
+        if (cachedMetadata != null) {
+            cachedMetadata.setCached(true);
+            return Optional.of(cachedMetadata);
+        }
+
+        GoogleComputeInstanceMetadata instanceMetadata = null;
+
+        try {
+            int connectionTimeoutMs = (int) configuration.getConnectTimeout().toMillis();
+            int readTimeoutMs = (int) configuration.getReadTimeout().toMillis();
+            Map<String, String> requestProperties = new HashMap<>();
+            requestProperties.put(HEADER_METADATA_FLAVOR, "Google");
+            JsonNode projectResultJson = null;
+            try {
+                projectResultJson = readMetadataUrl(
+                        new URL(configuration.getProjectMetadataUrl() + "?recursive=true"),
+                        connectionTimeoutMs,
+                        readTimeoutMs,
+                        objectMapper,
+                        requestProperties);
+            } catch (MalformedURLException me) {
+                if (LOG.isErrorEnabled()) {
+                    LOG.error("Google compute project metadataUrl value is invalid!: " + configuration.getProjectMetadataUrl(), me);
+                }
+            } catch (FileNotFoundException fnfe) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("No project metadata found at: " + configuration.getProjectMetadataUrl() + "?recursive=true", fnfe);
+                }
+            } catch (IOException ioe) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Error connecting to" + configuration.getProjectMetadataUrl() + "?recursive=true reading project metadata. Not a Google environment?", ioe);
+                }
+            }
+            JsonNode instanceMetadataJson = readMetadataUrl(new URL(configuration.getMetadataUrl() + "?recursive=true"), connectionTimeoutMs, readTimeoutMs, objectMapper, requestProperties);
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Read compute instance metadata from URL [{}]. Resulting JSON: {}", configuration.getMetadataUrl(), instanceMetadataJson);
+            }
+
+
+            if (environment.getActiveNames().contains(Environment.GAE)) {
+                instanceMetadata = new GoogleComputeInstanceMetadata();
+                instanceMetadata.setInstanceId(System.getenv("GAE_INSTANCE"));
+                instanceMetadata.setAccount(System.getenv("GOOGLE_CLOUD_PROJECT"));
+            }
+
+            if (instanceMetadataJson != null) {
+                if (instanceMetadata == null) {
+                    instanceMetadata = new GoogleComputeInstanceMetadata();
+                }
+                stringValue(instanceMetadataJson, GoogleComputeMetadataKeys.ID.getName()).ifPresent(instanceMetadata::setInstanceId);
+                if (projectResultJson != null) {
+                    stringValue(projectResultJson, GoogleComputeMetadataKeys.PROJECT_ID.getName()).ifPresent(instanceMetadata::setAccount);
+                } else {
+                    stringValue(instanceMetadataJson, GoogleComputeMetadataKeys.PROJECT_ID.getName()).ifPresent(instanceMetadata::setAccount);
+                }
+                stringValue(instanceMetadataJson, GoogleComputeMetadataKeys.ZONE.getName()).ifPresent(instanceMetadata::setAvailabilityZone);
+                stringValue(instanceMetadataJson, GoogleComputeMetadataKeys.MACHINE_TYPE.getName()).ifPresent(instanceMetadata::setMachineType);
+                stringValue(instanceMetadataJson, GoogleComputeMetadataKeys.DESCRIPTION.getName()).ifPresent(instanceMetadata::setDescription);
+                stringValue(instanceMetadataJson, GoogleComputeMetadataKeys.IMAGE.getName()).ifPresent(instanceMetadata::setImageId);
+                stringValue(instanceMetadataJson, GoogleComputeMetadataKeys.HOSTNAME.getName()).ifPresent(instanceMetadata::setLocalHostname);
+                stringValue(instanceMetadataJson, GoogleComputeMetadataKeys.NAME.getName()).ifPresent(instanceMetadata::setName);
+
+                JsonNode networkInterfaces = instanceMetadataJson.findValue(GoogleComputeMetadataKeys.NETWORK_INTERFACES.getName());
+                if (networkInterfaces != null) {
+
+                    List<NetworkInterface> interfaces = new ArrayList<>();
+                    AtomicInteger networkCounter = new AtomicInteger(0);
+                    GoogleComputeInstanceMetadata finalInstanceMetadata = instanceMetadata;
+                    networkInterfaces.elements().forEachRemaining(
+                            jsonNode -> {
+                                GoogleComputeNetworkInterface networkInterface = new GoogleComputeNetworkInterface();
+                                networkInterface.setId(String.valueOf(networkCounter.getAndIncrement()));
+
+                                if (jsonNode.findValue(GoogleComputeMetadataKeys.ACCESS_CONFIGS.getName()) != null) {
+                                    JsonNode accessConfigs = jsonNode.findValue(GoogleComputeMetadataKeys.ACCESS_CONFIGS.getName());
+                                    // we just grab the first one
+                                    finalInstanceMetadata.setPublicIpV4(accessConfigs.get(0).findValue("externalIp").textValue());
+                                }
+
+                                stringValue(jsonNode, GoogleComputeMetadataKeys.IP.getName()).ifPresent(finalInstanceMetadata::setPrivateIpV4);
+                                stringValue(jsonNode, GoogleComputeMetadataKeys.IP.getName()).ifPresent(networkInterface::setIpv4);
+                                stringValue(jsonNode, GoogleComputeMetadataKeys.MAC.getName()).ifPresent(networkInterface::setMac);
+                                stringValue(jsonNode, GoogleComputeMetadataKeys.NETWORK.getName()).ifPresent(networkInterface::setNetwork);
+                                stringValue(jsonNode, GoogleComputeMetadataKeys.NETMASK.getName()).ifPresent(networkInterface::setNetmask);
+                                stringValue(jsonNode, GoogleComputeMetadataKeys.GATEWAY.getName()).ifPresent(networkInterface::setGateway);
+                                interfaces.add(networkInterface);
+                            });
+                    instanceMetadata.setInterfaces(interfaces);
+                }
+                final Map<?, ?> metadata = objectMapper.convertValue(instanceMetadata, Map.class);
+                populateMetadata(instanceMetadata, metadata);
+                cachedMetadata = instanceMetadata;
+
+                return Optional.of(instanceMetadata);
+            }
+        } catch (MalformedURLException me) {
+            if (LOG.isErrorEnabled()) {
+                LOG.error("Google compute metadataUrl value is invalid!: " + configuration.getMetadataUrl(), me);
+            }
+        } catch (FileNotFoundException fnfe) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("No metadata found at: " + configuration.getMetadataUrl() + "?recursive=true", fnfe);
+            }
+        } catch (IOException ioe) {
+            if (LOG.isErrorEnabled()) {
+                LOG.debug("Error connecting to" + configuration.getMetadataUrl() + "?recursive=true reading instance metadata", ioe);
+            }
+        }
+
+        return Optional.ofNullable(instanceMetadata);
+    }
+
+}

--- a/gcp-common/src/main/java/io/micronaut/discovery/cloud/gcp/GoogleComputeMetadataConfiguration.java
+++ b/gcp-common/src/main/java/io/micronaut/discovery/cloud/gcp/GoogleComputeMetadataConfiguration.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.cloud.gcp;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.util.Toggleable;
+import io.micronaut.runtime.ApplicationConfiguration;
+
+import java.time.Duration;
+
+/**
+ * Configuration for computing metadata for {@link io.micronaut.context.env.ComputePlatform#GOOGLE_COMPUTE}.
+ *
+ * @author graemerocher
+ * @since 1.0
+ */
+@ConfigurationProperties(GoogleComputeMetadataConfiguration.PREFIX)
+@Requires(env = Environment.GOOGLE_COMPUTE)
+@Primary
+public class GoogleComputeMetadataConfiguration implements Toggleable {
+
+    /**
+     * Prefix for Google Compute configuration.
+     */
+    public static final String PREFIX = ApplicationConfiguration.PREFIX + "." + Environment.GOOGLE_COMPUTE + ".metadata";
+
+    /**
+     * The default enable value.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final boolean DEFAULT_ENABLED = true;
+
+    /**
+     * The default metadata url value.
+     */
+    @SuppressWarnings("WeakerAccess")
+    // CHECKSTYLE:OFF
+    public static final String DEFAULT_METADATAURL = "http://metadata.google.internal/computeMetadata/v1/project/";
+    // CHECKSTYLE:ON
+
+    /**
+     * The default project metadata url value.
+     */
+    @SuppressWarnings("WeakerAccess")
+    // CHECKSTYLE:OFF
+    public static final String DEFAULT_PROJECTMETADATAURL = "http://metadata.google.internal/project/v1/project/";
+    // CHECKSTYLE:ON
+
+    /**
+     * The default read timeout in seconds.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final int DEFAULT_READTIMEOUT = 5;
+
+    /**
+     * The default connect timeout in seconds.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final int DEFAULT_CONNECTTIMEOUT = 2;
+
+    private boolean enabled = DEFAULT_ENABLED;
+    private String metadataUrl = DEFAULT_METADATAURL;
+    private String projectMetadataUrl = DEFAULT_PROJECTMETADATAURL;
+    private Duration readTimeout = Duration.ofSeconds(DEFAULT_READTIMEOUT);
+    private Duration connectTimeout = Duration.ofSeconds(DEFAULT_CONNECTTIMEOUT);
+
+    /**
+     * @return Whether the Google Compute configuration is enabled
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Default value ({@value #DEFAULT_ENABLED}).
+     * @param enabled Enable or disable the Google Compute configuration
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * @return The metadata Url
+     */
+    public String getMetadataUrl() {
+        return metadataUrl;
+    }
+
+    /**
+     * Default value ({@value #DEFAULT_METADATAURL}).
+     * @param metadataUrl The metadata Url
+     */
+    public void setMetadataUrl(String metadataUrl) {
+        this.metadataUrl = metadataUrl;
+    }
+
+    /**
+     * @return The project metadata Url
+     */
+    public String getProjectMetadataUrl() {
+        return projectMetadataUrl;
+    }
+
+    /**
+     * Default value ({@value #DEFAULT_PROJECTMETADATAURL}).
+     * @param projectMetadataUrl The project metadata Url
+     */
+    public void setProjectMetadataUrl(String projectMetadataUrl) {
+        this.projectMetadataUrl = projectMetadataUrl;
+    }
+
+    /**
+     * @return The read timeout
+     */
+    public Duration getReadTimeout() {
+        return readTimeout;
+    }
+
+    /**
+     * Default value ({@value #DEFAULT_READTIMEOUT} seconds).
+     * @param readTimeout The read timeout
+     */
+    public void setReadTimeout(Duration readTimeout) {
+        this.readTimeout = readTimeout;
+    }
+
+    /**
+     * @return The connect timeout
+     */
+    public Duration getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    /**
+     * Default value ({@value #DEFAULT_CONNECTTIMEOUT}).
+     * @param connectTimeout The connect timeout
+     */
+    public void setConnectTimeout(Duration connectTimeout) {
+        this.connectTimeout = connectTimeout;
+    }
+}

--- a/gcp-common/src/main/java/io/micronaut/discovery/cloud/gcp/GoogleComputeMetadataKeys.java
+++ b/gcp-common/src/main/java/io/micronaut/discovery/cloud/gcp/GoogleComputeMetadataKeys.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.cloud.gcp;
+
+/**
+ * Models common Google compute instance metadata keys.
+ *
+ * @author rvanderwerf
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+public enum GoogleComputeMetadataKeys {
+
+    DESCRIPTION("description"),
+    HOSTNAME("hostname"),
+    ID("id"),
+    ATTRIBUTES("attributes"),
+    CPU_PLATFORM("cpuPlatform"),
+    DISKS("disks"),
+    DNS_SERVERS("dnsServers"),
+    FORWARDED_IPS("forewardedIps"),
+    GATEWAY("gateway"),
+    IP("ip"),
+    IP_ALIASES("ipAliases"),
+    MAC("mac"),
+    NETWORK("network"),
+    SCOPES("scopes"),
+    MACHINE_TYPE("machineType"),
+    MAINTENANCE_EVENT("maintenanceEvent"),
+    NAME("name"),
+    NETWORK_INTERFACES("networkInterfaces"),
+    SERVICE_ACCOUNTS("serviceAccounts"),
+    DEFAULTS("default"),
+    PROJECT_ID("projectId"),
+    NUMERIC_PROJECT_ID("numericProjectId"),
+    ZONE("zone"),
+    TAGS("tags"),
+    VIRTUAL_CLOCK("virtualClock"),
+    IMAGE("image"),
+    LICENSES("licenses"),
+    ACCESS_CONFIGS("accessConfigs"),
+    NETMASK("subnetmask");
+
+    private final String name;
+
+    /**
+     * @param name The name of the metadata key represented in AWS Metadata.
+     */
+    GoogleComputeMetadataKeys(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return The name of the metadata key represented in AWS Metadata.
+     */
+    public String getName() {
+        return name;
+    }
+}

--- a/gcp-common/src/main/java/io/micronaut/discovery/cloud/gcp/GoogleComputeNetworkInterface.java
+++ b/gcp-common/src/main/java/io/micronaut/discovery/cloud/gcp/GoogleComputeNetworkInterface.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.cloud.gcp;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.discovery.cloud.NetworkInterface;
+
+/**
+ * A {@link NetworkInterface} implementation for Google.
+ *
+ * @author graemerocher
+ * @since 1.0
+ */
+@Internal
+class GoogleComputeNetworkInterface extends NetworkInterface {
+
+    @Override
+    protected void setIpv4(String ipv4) {
+        super.setIpv4(ipv4);
+    }
+
+    @Override
+    protected void setIpv6(String ipv6) {
+        super.setIpv6(ipv6);
+    }
+
+    @Override
+    protected void setName(String name) {
+        super.setName(name);
+    }
+
+    @Override
+    protected void setMac(String mac) {
+        super.setMac(mac);
+    }
+
+    @Override
+    protected void setId(String id) {
+        super.setId(id);
+    }
+
+    @Override
+    protected void setGateway(String gateway) {
+        super.setGateway(gateway);
+    }
+
+    @Override
+    protected void setNetwork(String network) {
+        super.setNetwork(network);
+    }
+
+    @Override
+    protected void setNetmask(String netmask) {
+        super.setNetmask(netmask);
+    }
+}

--- a/gcp-common/src/main/java/io/micronaut/discovery/cloud/gcp/package-info.java
+++ b/gcp-common/src/main/java/io/micronaut/discovery/cloud/gcp/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Google Compute cloud configuration.
+ *
+ * @author graemerocher
+ * @since 1.0
+ */
+package io.micronaut.discovery.cloud.gcp;
+


### PR DESCRIPTION
This migrates the GCP specific code in core to this project.

When merging the next version of this module we should delete the associated code from core.