### PR TITLE
- Added StackdriverTracePropagation to BraveConfiguration

### DIFF
--- a/gcp-tracing/src/main/java/io/micronaut/gcp/tracing/zipkin/StackdriverSenderFactory.java
+++ b/gcp-tracing/src/main/java/io/micronaut/gcp/tracing/zipkin/StackdriverSenderFactory.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.gcp.tracing.zipkin;
 
+import brave.propagation.B3Propagation;
 import brave.propagation.Propagation;
 import com.google.auth.oauth2.GoogleCredentials;
 import io.grpc.CallOptions;
@@ -120,6 +121,7 @@ public class StackdriverSenderFactory {
             BraveTracerConfiguration configurationBean = configuration.getBean();
 
             configurationBean.getTracingBuilder()
+                    .propagationFactory(brave.propagation.stackdriver.StackdriverTracePropagation.newFactory(B3Propagation.FACTORY))
                     .traceId128Bit(true)
                     .supportsJoin(false);
 


### PR DESCRIPTION
@graemerocher Found this while implementing the logging functionality. Currently Tracing is not configuring the `XCloudTraceContextExtractor` to extract headers from GCP `x-cloud-trace-context`. Inside AppEngine for instance without this we would never continue a span that is pushed from the environment. 

It seems that this was missing, but would be nice to get a second opinion to make sure that I'm not misinterpreting this. 