### PR TITLE
Enabling Pub/Sub emulator

### DIFF
--- a/gcp-common/build.gradle
+++ b/gcp-common/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:$micronautDocsVersion"
 
     compileOnly "io.micronaut:micronaut-runtime"
+    compileOnly "io.micronaut:micronaut-inject-java"
     api "io.micronaut:micronaut-inject:$micronautVersion"
     api 'com.google.auth:google-auth-library-oauth2-http:0.21.1'
     api 'com.google.cloud:google-cloud-core:1.93.9'

--- a/gcp-common/build.gradle
+++ b/gcp-common/build.gradle
@@ -3,7 +3,6 @@ dependencies {
     annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:$micronautDocsVersion"
 
     compileOnly "io.micronaut:micronaut-runtime"
-    compileOnly "io.micronaut:micronaut-inject-java"
     api "io.micronaut:micronaut-inject:$micronautVersion"
     api 'com.google.auth:google-auth-library-oauth2-http:0.21.1'
     api 'com.google.cloud:google-cloud-core:1.93.9'

--- a/gcp-common/src/main/java/io/micronaut/gcp/Modules.java
+++ b/gcp-common/src/main/java/io/micronaut/gcp/Modules.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gcp;
+
+/**
+ * Provides names of implemented modules to be used as {@link javax.inject.Named} qualifiers as a well for {@link UserAgentHeaderProvider}.
+ *
+ * @author Vinicius Carvalho
+ */
+public interface Modules {
+    /**
+     * Module name for the gcp-tracing.
+     */
+    String TRACING = "trace";
+
+    /**
+     * Module name for gcp-pubsub.
+     */
+    String PUBSUB = "pubsub";
+
+}

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/bind/DefaultSubscriberFactory.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/bind/DefaultSubscriberFactory.java
@@ -22,6 +22,7 @@ import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.cloud.pubsub.v1.SubscriberInterface;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import io.micronaut.context.BeanContext;
+import io.micronaut.gcp.Modules;
 import io.micronaut.gcp.pubsub.configuration.SubscriberConfigurationProperties;
 import io.micronaut.gcp.pubsub.exception.PubSubListenerException;
 import io.micronaut.inject.qualifiers.Qualifiers;
@@ -29,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PreDestroy;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.Iterator;
 import java.util.Map;
@@ -51,8 +53,8 @@ public class DefaultSubscriberFactory implements SubscriberFactory, AutoCloseabl
     private final BeanContext beanContext;
     private final Logger logger = LoggerFactory.getLogger(DefaultSubscriberFactory.class);
 
-    public DefaultSubscriberFactory(TransportChannelProvider transportChannelProvider,
-                                    CredentialsProvider credentialsProvider,
+    public DefaultSubscriberFactory(@Named(Modules.PUBSUB) TransportChannelProvider transportChannelProvider,
+                                    @Named(Modules.PUBSUB) CredentialsProvider credentialsProvider,
                                     BeanContext beanContext) {
         this.transportChannelProvider = transportChannelProvider;
         this.credentialsProvider = credentialsProvider;

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/support/DefaultPublisherFactory.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/support/DefaultPublisherFactory.java
@@ -22,11 +22,13 @@ import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.pubsub.v1.ProjectTopicName;
 import io.micronaut.context.BeanContext;
+import io.micronaut.gcp.Modules;
 import io.micronaut.gcp.pubsub.configuration.PublisherConfigurationProperties;
 import io.micronaut.gcp.pubsub.exception.PubSubClientException;
 import io.micronaut.inject.qualifiers.Qualifiers;
 
 import javax.annotation.Nonnull;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -55,8 +57,8 @@ public class DefaultPublisherFactory implements PublisherFactory {
     private final CredentialsProvider credentialsProvider;
     private final BeanContext beanContext;
 
-    public DefaultPublisherFactory(TransportChannelProvider transportChannelProvider,
-                                   CredentialsProvider credentialsProvider,
+    public DefaultPublisherFactory(@Named(Modules.PUBSUB) TransportChannelProvider transportChannelProvider,
+                                   @Named(Modules.PUBSUB) CredentialsProvider credentialsProvider,
                                    BeanContext beanContext) {
         this.transportChannelProvider = transportChannelProvider;
         this.credentialsProvider = credentialsProvider;

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/configuration/PubSubEmulatorSpec.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/configuration/PubSubEmulatorSpec.groovy
@@ -1,0 +1,34 @@
+package io.micronaut.gcp.pubsub.configuration
+
+import com.google.api.gax.core.CredentialsProvider
+import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.api.gax.core.NoCredentialsProvider
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider
+import com.google.api.gax.rpc.FixedTransportChannelProvider
+import com.google.api.gax.rpc.TransportChannelProvider
+import io.micronaut.context.ApplicationContext
+import io.micronaut.gcp.Modules
+import io.micronaut.inject.qualifiers.Qualifiers
+import spock.lang.Specification
+
+class PubSubEmulatorSpec extends Specification{
+
+    void "test environment without pubsub emulator"() {
+        ApplicationContext ctx = ApplicationContext.run()
+        CredentialsProvider provider = ctx.getBean(CredentialsProvider, Qualifiers.byName(Modules.PUBSUB))
+        TransportChannelProvider transportChannelProvider = ctx.getBean(TransportChannelProvider, Qualifiers.byName(Modules.PUBSUB))
+        expect:
+            provider instanceof FixedCredentialsProvider
+            transportChannelProvider instanceof InstantiatingGrpcChannelProvider
+    }
+    void "test environment with pubsub emulator"() {
+        ApplicationContext ctx = ApplicationContext.run([
+                "pubsub.emulator.host" : "localhost:8085"])
+        CredentialsProvider provider = ctx.getBean(CredentialsProvider, Qualifiers.byName(Modules.PUBSUB))
+        TransportChannelProvider transportChannelProvider = ctx.getBean(TransportChannelProvider, Qualifiers.byName(Modules.PUBSUB))
+
+        expect:
+            provider instanceof NoCredentialsProvider
+            transportChannelProvider instanceof FixedTransportChannelProvider
+    }
+}

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/configuration/PubSubEmulatorSpec.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/configuration/PubSubEmulatorSpec.groovy
@@ -6,10 +6,17 @@ import com.google.api.gax.core.NoCredentialsProvider
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider
 import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.api.gax.rpc.TransportChannelProvider
+import com.google.auth.oauth2.AccessToken
+import com.google.auth.oauth2.GoogleCredentials
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Replaces
 import io.micronaut.gcp.Modules
 import io.micronaut.inject.qualifiers.Qualifiers
 import spock.lang.Specification
+import spock.mock.MockingApi
+
+import javax.inject.Singleton
 
 class PubSubEmulatorSpec extends Specification{
 
@@ -30,5 +37,15 @@ class PubSubEmulatorSpec extends Specification{
         expect:
             provider instanceof NoCredentialsProvider
             transportChannelProvider instanceof FixedTransportChannelProvider
+    }
+}
+
+@Factory
+class EmptyCredentialsFactory {
+
+    @Singleton
+    @Replaces(GoogleCredentials)
+    GoogleCredentials mockCredentials() {
+        return GoogleCredentials.create(new AccessToken("", new Date()))
     }
 }

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/configuration/PubSubEmulatorSpec.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/configuration/PubSubEmulatorSpec.groovy
@@ -11,36 +11,49 @@ import com.google.auth.oauth2.GoogleCredentials
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
 import io.micronaut.gcp.Modules
 import io.micronaut.inject.qualifiers.Qualifiers
 import spock.lang.Specification
-import spock.mock.MockingApi
 
 import javax.inject.Singleton
 
 class PubSubEmulatorSpec extends Specification{
 
     void "test environment without pubsub emulator"() {
-        ApplicationContext ctx = ApplicationContext.run()
-        CredentialsProvider provider = ctx.getBean(CredentialsProvider, Qualifiers.byName(Modules.PUBSUB))
-        TransportChannelProvider transportChannelProvider = ctx.getBean(TransportChannelProvider, Qualifiers.byName(Modules.PUBSUB))
-        expect:
-            provider instanceof FixedCredentialsProvider
-            transportChannelProvider instanceof InstantiatingGrpcChannelProvider
-    }
-    void "test environment with pubsub emulator"() {
+        given:
         ApplicationContext ctx = ApplicationContext.run([
-                "pubsub.emulator.host" : "localhost:8085"])
+            'spec.name': 'PubSubEmulatorSpec'
+        ])
+
+        when:
         CredentialsProvider provider = ctx.getBean(CredentialsProvider, Qualifiers.byName(Modules.PUBSUB))
         TransportChannelProvider transportChannelProvider = ctx.getBean(TransportChannelProvider, Qualifiers.byName(Modules.PUBSUB))
 
-        expect:
-            provider instanceof NoCredentialsProvider
-            transportChannelProvider instanceof FixedTransportChannelProvider
+        then:
+        provider instanceof FixedCredentialsProvider
+        transportChannelProvider instanceof InstantiatingGrpcChannelProvider
+    }
+
+    void "test environment with pubsub emulator"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.run([
+            'spec.name': 'PubSubEmulatorSpec',
+            "pubsub.emulator.host" : "localhost:8085"
+        ])
+
+        when:
+        CredentialsProvider provider = ctx.getBean(CredentialsProvider, Qualifiers.byName(Modules.PUBSUB))
+        TransportChannelProvider transportChannelProvider = ctx.getBean(TransportChannelProvider, Qualifiers.byName(Modules.PUBSUB))
+
+        then:
+        provider instanceof NoCredentialsProvider
+        transportChannelProvider instanceof FixedTransportChannelProvider
     }
 }
 
 @Factory
+@Requires(property = 'spec.name', value = 'PubSubEmulatorSpec')
 class EmptyCredentialsFactory {
 
     @Singleton

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/integration/IntegrationTest.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/integration/IntegrationTest.groovy
@@ -18,6 +18,7 @@ import io.grpc.ManagedChannelBuilder
 import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Replaces
+import io.micronaut.gcp.Modules
 import io.micronaut.gcp.pubsub.annotation.PubSubClient
 import io.micronaut.gcp.pubsub.annotation.PubSubListener
 import io.micronaut.gcp.pubsub.annotation.Subscription
@@ -31,6 +32,7 @@ import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 
 @MicronautTest
@@ -66,6 +68,7 @@ class IntegrationTest extends Specification{
             .withCommand("gcloud", "beta", "emulators", "pubsub", "start", "--project=test-project",
                     "--host-port=0.0.0.0:8085")
             .withExposedPorts(8085)
+
             .waitingFor(new LogMessageWaitStrategy().withRegEx("(?s).*Server started, listening on.*"))
 
     static {
@@ -81,12 +84,14 @@ class IntegrationTestFactory {
 
     @Replaces(CredentialsProvider)
     @Singleton
+    @Named(Modules.PUBSUB)
     CredentialsProvider credentialsProvider() {
         return NoCredentialsProvider.create()
     }
 
     @Replaces(TransportChannelProvider)
     @Singleton
+    @Named(Modules.PUBSUB)
     TransportChannelProvider transportChannelProvider(CredentialsProvider credentialsProvider){
         def host = "localhost:" + IntegrationTest.CONTAINER_PORT
         ManagedChannel channel = ManagedChannelBuilder.forTarget(host).usePlaintext().build()

--- a/gcp-tracing/src/main/java/io/micronaut/gcp/tracing/zipkin/StackdriverSenderFactory.java
+++ b/gcp-tracing/src/main/java/io/micronaut/gcp/tracing/zipkin/StackdriverSenderFactory.java
@@ -29,6 +29,7 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.event.BeanCreatedEventListener;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.gcp.GoogleCloudConfiguration;
+import io.micronaut.gcp.Modules;
 import io.micronaut.gcp.UserAgentHeaderProvider;
 import io.micronaut.gcp.condition.RequiresGoogleProjectId;
 import io.micronaut.tracing.brave.AsyncReporterConfiguration;
@@ -79,7 +80,7 @@ public class StackdriverSenderFactory {
     @Bean(preDestroy = "shutdownNow")
     @Named("stackdriverTraceSenderChannel")
     protected @Nonnull ManagedChannel stackdriverTraceSenderChannel() {
-        UserAgentHeaderProvider userAgentHeaderProvider = new UserAgentHeaderProvider("trace");
+        UserAgentHeaderProvider userAgentHeaderProvider = new UserAgentHeaderProvider(Modules.TRACING);
 
         return ManagedChannelBuilder.forTarget(TRACE_TARGET)
                 .userAgent(userAgentHeaderProvider.getUserAgent())

--- a/src/main/docs/guide/pubsub/emulator.adoc
+++ b/src/main/docs/guide/pubsub/emulator.adoc
@@ -1,0 +1,14 @@
+Google Cloud Pub/Sub has a local link:https://cloud.google.com/pubsub/docs/emulator#emulator_command-line_arguments[emulator] to enable developers to test their applications locally with no need to connect to the cloud Pub/Sub service.
+
+The framework supports automatic switching of the `TransportChannelProvider` to use `PUBSUB_EMULATOR_HOST` if this variable is set on the environment.
+
+NOTE: Make sure that you also set `GCP_PROJECT_ID` to be the same as the project you have configured the emulator to use. Otherwise the framework may pick up the projectId used by the default credentials.
+
+You will need to manually configure topics and subscriptions on the emulator if you want to test locally. You can easily create resources using the link:https://cloud.google.com/pubsub/docs/reference/rest[Pub/Sub REST interface] to create topics and subscriptions.
+
+For instance, the following `curl` command would create a topic named `micronaut-devices` on the `test-project` project.
+
+```
+curl -XPUT $PUBSUB_EMULATOR_HOST/v1/projects/test-project/topics/micronaut-devices
+```
+

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -32,3 +32,4 @@ pubsub:
   serdes:
     title: Message Serialization/Deserialization (SerDes)
   executors: Configuring Thread pools
+  emulator: Using Google Cloud Pub/Sub emulator


### PR DESCRIPTION
Fixes #257 

-Included a new Modules interface
- Added Qualifier to both TransportChannelProvider and CredentialsProvider (after started working on secret-manager it was clear we will need qualifiers of those beans for each module).

@graemerocher please take a look into `gcp-common/build.gradle` I've added back `micronaut-inject-java` as some tests were failing on intellij (or please advise on the proper way to fix)