### PR TITLE
Add getters and setters to StackdriverJsonLayout

### DIFF
--- a/gcp-logging/src/main/java/io/micronaut/gcp/logging/StackdriverJsonLayout.java
+++ b/gcp-logging/src/main/java/io/micronaut/gcp/logging/StackdriverJsonLayout.java
@@ -148,4 +148,44 @@ public class StackdriverJsonLayout extends JsonLayout {
 
         add(StackdriverTraceConstants.TRACE_ID_ATTRIBUTE, this.includeTraceId, traceId, map);
     }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public boolean isIncludeTraceId() {
+        return includeTraceId;
+    }
+
+    public void setIncludeTraceId(boolean includeTraceId) {
+        this.includeTraceId = includeTraceId;
+    }
+
+    public boolean isIncludeSpanId() {
+        return includeSpanId;
+    }
+
+    public void setIncludeSpanId(boolean includeSpanId) {
+        this.includeSpanId = includeSpanId;
+    }
+
+    public boolean isIncludeExceptionInMessage() {
+        return includeExceptionInMessage;
+    }
+
+    public void setIncludeExceptionInMessage(boolean includeExceptionInMessage) {
+        this.includeExceptionInMessage = includeExceptionInMessage;
+    }
+
+    public Map<String, Object> getCustomJson() {
+        return customJson;
+    }
+
+    public void setCustomJson(Map<String, Object> customJson) {
+        this.customJson = customJson;
+    }
 }


### PR DESCRIPTION
Tried using `micronaut-gcp-logging`. When starting an app logback outputs as if the `logback.xml` configuration contains the `debug="true"` flag. This is not the case, it outputs these debug messages because of an error:

```
06:46:41,691 |-ERROR in ch.qos.logback.core.joran.spi.Interpreter@13:28 - no applicable action for [projectId], current ElementPath  is [[configuration][appender][encoder][layout][projectId]]
```

I expect adding these getters and setters helps with this