### PR TITLE
Shutdown publishers after context is closed

### DIFF
--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/support/PubSubPublisherState.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/support/PubSubPublisherState.java
@@ -23,7 +23,6 @@ import io.micronaut.core.type.Argument;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Stores the context of a PubSubMessage to be pulished. Values of this class comes from parsing of method
@@ -32,7 +31,7 @@ import java.util.concurrent.TimeUnit;
  * @author Vinicius Carvalho
  * @since 2.0.0
  */
-public class PubSubPublisherState implements AutoCloseable{
+public class PubSubPublisherState implements AutoCloseable {
 
     private final TopicState topicState;
     private final Map<String, String> staticMessageAttributes;
@@ -95,12 +94,15 @@ public class PubSubPublisherState implements AutoCloseable{
     @Override
     public void close() throws Exception {
         //Lite and Default PubSub have different ancestors for resource management, hence the not so elegant type check
-        if(this.publisher instanceof Publisher) {
+        if (this.publisher instanceof Publisher) {
             Publisher defaultPublisher = (Publisher) this.publisher;
             defaultPublisher.shutdown();
         }
     }
 
+    /**
+     * Internal class to represent Topic State.
+     */
     public static class TopicState {
 
         private final String contentType;

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/support/PubSubPublisherState.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/support/PubSubPublisherState.java
@@ -16,12 +16,14 @@
 package io.micronaut.gcp.pubsub.support;
 
 
+import com.google.cloud.pubsub.v1.Publisher;
 import com.google.cloud.pubsub.v1.PublisherInterface;
 import com.google.pubsub.v1.ProjectTopicName;
 import io.micronaut.core.type.Argument;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Stores the context of a PubSubMessage to be pulished. Values of this class comes from parsing of method
@@ -30,7 +32,7 @@ import java.util.Optional;
  * @author Vinicius Carvalho
  * @since 2.0.0
  */
-public class PubSubPublisherState {
+public class PubSubPublisherState implements AutoCloseable{
 
     private final TopicState topicState;
     private final Map<String, String> staticMessageAttributes;
@@ -88,6 +90,15 @@ public class PubSubPublisherState {
      */
     public Optional<Argument> getOrderingArgument() {
         return orderingArgument;
+    }
+
+    @Override
+    public void close() throws Exception {
+        //Lite and Default PubSub have different ancestors for resource management, hence the not so elegant type check
+        if(this.publisher instanceof Publisher) {
+            Publisher defaultPublisher = (Publisher) this.publisher;
+            defaultPublisher.shutdown();
+        }
     }
 
     public static class TopicState {

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/AbstractPublisherSpec.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/AbstractPublisherSpec.groovy
@@ -5,7 +5,6 @@ import com.google.cloud.pubsub.v1.Publisher
 import com.google.pubsub.v1.PubsubMessage
 import io.micronaut.context.annotation.Replaces
 import io.micronaut.gcp.pubsub.support.PublisherFactory
-import io.micronaut.test.annotation.MockBean
 import spock.lang.Specification
 
 /**
@@ -15,7 +14,6 @@ import spock.lang.Specification
 
 abstract class AbstractPublisherSpec extends Specification {
 
-    @MockBean
     @Replaces(PublisherFactory)
     PublisherFactory publisherFactory() {
         def factory = Mock(PublisherFactory)

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/AbstractPublisherSpec.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/AbstractPublisherSpec.groovy
@@ -5,6 +5,7 @@ import com.google.cloud.pubsub.v1.Publisher
 import com.google.pubsub.v1.PubsubMessage
 import io.micronaut.context.annotation.Replaces
 import io.micronaut.gcp.pubsub.support.PublisherFactory
+import io.micronaut.test.annotation.MockBean
 import spock.lang.Specification
 
 /**
@@ -14,6 +15,7 @@ import spock.lang.Specification
 
 abstract class AbstractPublisherSpec extends Specification {
 
+    @MockBean
     @Replaces(PublisherFactory)
     PublisherFactory publisherFactory() {
         def factory = Mock(PublisherFactory)

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/integration/IntegrationTest.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/integration/IntegrationTest.groovy
@@ -37,6 +37,8 @@ class IntegrationTest extends IntegrationTestSpec{
             conditions.eventually {
                 listener.data.name == person.name
             }
+        cleanup:
+            ctx.close()
 
     }
 

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/integration/MessageOrderingTests.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/integration/MessageOrderingTests.groovy
@@ -32,9 +32,10 @@ class MessageOrderingTests extends IntegrationTestSpec {
             client.send(person)
         then:
             conditions.eventually {
-            listener.data.name == person.name
-        }
-
+                listener.data.name == person.name
+            }
+        cleanup:
+            ctx.close()
     }
 
     void "publish message to with ordering key"() {
@@ -53,12 +54,13 @@ class MessageOrderingTests extends IntegrationTestSpec {
         person.name = "alf"
 
         when:
-        client.send(person, 42)
+            client.send(person, 42)
         then:
-        conditions.eventually {
-            listener.data.name == person.name
-        }
-
+            conditions.eventually {
+                listener.data.name == person.name
+            }
+        cleanup:
+            ctx.close()
     }
 
 }


### PR DESCRIPTION

Publishers were missing a hook to properly shutdown. In preparation for lite support PublisherState checks the type and casts accordingly.

Added cleanup section to tests