### PR TITLE
Make STDOUT.withJansi configurable

### DIFF
--- a/gcp-logging/src/main/resources/io/micronaut/gcp/logging/logback-json-appender.xml
+++ b/gcp-logging/src/main/resources/io/micronaut/gcp/logging/logback-json-appender.xml
@@ -5,7 +5,7 @@ Stackdriver json-log format provided for import.
 <included>
     <define name="google_cloud_logging" class="io.micronaut.gcp.logging.GoogleCloudPropertyDefiner"></define>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <withJansi>true</withJansi>
+        <withJansi>${STDOUT_WITH_JANSI:-true}</withJansi>
         <encoder>
             <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n </pattern>
         </encoder>

--- a/gcp-logging/src/main/resources/io/micronaut/gcp/logging/logback-json-appender.xml
+++ b/gcp-logging/src/main/resources/io/micronaut/gcp/logging/logback-json-appender.xml
@@ -5,7 +5,7 @@ Stackdriver json-log format provided for import.
 <included>
     <define name="google_cloud_logging" class="io.micronaut.gcp.logging.GoogleCloudPropertyDefiner"></define>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <withJansi>${STDOUT_WITH_JANSI:-true}</withJansi>
+        <withJansi>${STDOUT_WITH_JANSI:-false}</withJansi>
         <encoder>
             <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n </pattern>
         </encoder>

--- a/src/main/docs/guide/logging.adoc
+++ b/src/main/docs/guide/logging.adoc
@@ -26,6 +26,8 @@ image::logs_json.png[JSON log output,1591,534]
 [source,xml]
 ----
 <configuration>
+    <!-- Uncomment the next line to enable ANSI color code interpretation -->
+    <!-- <property name="STDOUT_WITH_JANSI" value="true" /> -->
     <include resource="io/micronaut/gcp/logging/logback-json-appender.xml" /> <1>
     <root level="INFO">
         <appender-ref ref="CONSOLE_JSON" /> <2>


### PR DESCRIPTION

Fixes #455

I've made `STDOUT.withJansi` configurable via Logback property `STDOUT_WITH_JANSI`.

The default value is still `true`, to maintain backward compatibility; but at least this change would allow users to solve the issue on Windows by defining `STDOUT_WITH_JANSI` as an environment variable, or a Logback property:

```xml
<configuration>
    <property name="STDOUT_WITH_JANSI" value="false" />
    <include resource="io/micronaut/gcp/logging/logback-json-appender.xml" /> 
    <root level="INFO">
        <appender-ref ref="CONSOLE_JSON" /> 
    </root>
</configuration>
```

Let me know if the PR looks good to you and feel free to edit it.