### PR TITLE
Remove @Primary from DefaultPubSubMessageReceiverExceptionHandler

### DIFF
--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/exception/DefaultPubSubMessageReceiverExceptionHandler.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/exception/DefaultPubSubMessageReceiverExceptionHandler.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.gcp.pubsub.exception;
 
-import io.micronaut.context.annotation.Primary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +30,6 @@ import jakarta.inject.Singleton;
  * @since 2.0.0
  */
 @Singleton
-@Primary
 public class DefaultPubSubMessageReceiverExceptionHandler implements PubSubMessageReceiverExceptionHandler {
 
     private final Logger logger = LoggerFactory.getLogger(DefaultPubSubMessageReceiverExceptionHandler.class);

--- a/src/main/docs/guide/pubsub/pullConsumer/errorHandling.adoc
+++ b/src/main/docs/guide/pubsub/pullConsumer/errorHandling.adoc
@@ -10,7 +10,7 @@ The framework provides a Global Error Handler api:gcp.pubsub.exception.DefaultPu
 There's two ways you can provide error handling.
 
 * Locally: your ann:gcp.pubsub.annotation.PubSubListener[] class implements api:gcp.pubsub.exception.PubSubMessageReceiverExceptionHandler[], then any error related to `Subscriptions` of that class will be handled by your class.
-* Globally: You define a new implementation of api:gcp.pubsub.exception.PubSubMessageReceiverExceptionHandler[] and annotate it as `@Primary` overriding the default one.
+* Globally: You define a new implementation of api:gcp.pubsub.exception.PubSubMessageReceiverExceptionHandler[] which link:https://docs.micronaut.io/latest/guide/#replaces[replaces] api:gcp.pubsub.exception.DefaultPubSubMessageReceiverExceptionHandler[].
 
 The api:exception.PubSubMessageReceiverException[] contains references to the originating bean that threw the exception as well as a reference to api:bind.PubSubConsumerState[] which has state information regarding the message handling.
 


### PR DESCRIPTION
Fixes #465 

- Remove `@Primary` qualifier from `DefaultPubSubMessageReceiverExceptionHandler`.
- Update documentation (replace the default bean instead of simply annotating the custom one as primary).
