### PR TITLE
Fix Cloud Trace Maven native-image compilation

### DIFF
--- a/gcp-tracing/build.gradle
+++ b/gcp-tracing/build.gradle
@@ -12,7 +12,11 @@ dependencies {
 
     implementation'io.zipkin.gcp:zipkin-sender-stackdriver:1.0.4'
     implementation 'io.zipkin.gcp:brave-propagation-stackdriver:1.0.4'
-    implementation 'io.grpc:grpc-auth:1.45.1'
+    implementation('io.grpc:grpc-auth:1.45.1'){
+        //grpc-auth pulls in an older version of google-auth-library-credentials
+        // which causes issues with maven native image compilation
+        exclude group: 'com.google.auth', module: 'google-auth-library-credentials'
+    }
 
     implementation 'io.grpc:grpc-netty-shaded:1.45.1'
     implementation "io.opentracing.brave:brave-opentracing:1.0.0"

--- a/gcp-tracing/build.gradle
+++ b/gcp-tracing/build.gradle
@@ -10,13 +10,10 @@ dependencies {
     api "io.micronaut.tracing:micronaut-tracing-zipkin"
     api "io.micronaut:micronaut-inject"
 
+    implementation "com.google.auth:google-auth-library-credentials:$googleAuthLibraryOauth2HttpVersion"
     implementation'io.zipkin.gcp:zipkin-sender-stackdriver:1.0.4'
     implementation 'io.zipkin.gcp:brave-propagation-stackdriver:1.0.4'
-    implementation('io.grpc:grpc-auth:1.45.1'){
-        //grpc-auth pulls in an older version of google-auth-library-credentials
-        // which causes issues with maven native image compilation
-        exclude group: 'com.google.auth', module: 'google-auth-library-credentials'
-    }
+    implementation('io.grpc:grpc-auth:1.45.1')
 
     implementation 'io.grpc:grpc-netty-shaded:1.45.1'
     implementation "io.opentracing.brave:brave-opentracing:1.0.0"


### PR DESCRIPTION
Excluding dependency `com.google.auth:google-auth-library-credentials` from `io.grpc:grpc-auth` because it uses an older version, which causes issues with maven native image compilation.