### PR TITLE
Add support for specifying default Topic endpoint

### DIFF
--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/annotation/Topic.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/annotation/Topic.java
@@ -59,7 +59,8 @@ public @interface Topic {
 
     /**
      * Sets the endpoint that PubSub will use to store messages.
-     * If not specified PubSub stores messages on the nearest endpoint to the client.
+     * If not specified the endpoint defined in properties will be used,
+     * else PubSub stores messages on the nearest endpoint to the client.
      * This is useful when regulations for data locality such as GDPR are in place.
      * @return the remote endpoint to use
      */

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/configuration/PubSubConfigurationProperties.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/configuration/PubSubConfigurationProperties.java
@@ -36,6 +36,8 @@ public class PubSubConfigurationProperties {
 
     private String subscribingExecutor = TaskExecutors.SCHEDULED;
 
+    private String topicEndpoint = "";
+
     /**
      *
      * @return the name of the {@link java.util.concurrent.ScheduledExecutorService} to be used by all {@link com.google.cloud.pubsub.v1.Publisher} instances. Default: "scheduled"
@@ -86,4 +88,19 @@ public class PubSubConfigurationProperties {
         this.keepAliveIntervalMinutes = keepAliveIntervalMinutes;
     }
 
+    /**
+     * Which endpoint the {@link com.google.cloud.pubsub.v1.Publisher} should publish messages to. Defaults to the global endpoint
+     * @return endpoint
+     */
+    public String getTopicEndpoint() {
+        return this.topicEndpoint;
+    }
+
+    /**
+     *
+     * @param topicEndpoint to be used by all {@link com.google.cloud.pubsub.v1.Publisher} instances. Default: "" (i.e. the global endpoint)
+     */
+    public void setTopicEndpoint(String topicEndpoint) {
+        this.topicEndpoint = topicEndpoint;
+    }
 }

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/intercept/PubSubClientIntroductionAdvice.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/intercept/PubSubClientIntroductionAdvice.java
@@ -103,7 +103,7 @@ public class PubSubClientIntroductionAdvice implements MethodInterceptor<Object,
                 String projectId = method.stringValue(PubSubClient.class).orElse(googleCloudConfiguration.getProjectId());
                 Optional<Argument> orderingArgument = Arrays.stream(method.getArguments()).filter(argument -> argument.getAnnotationMetadata().hasAnnotation(OrderingKey.class)).findFirst();
                 String topic = method.stringValue(Topic.class).orElse(context.getName());
-                String endpoint = method.stringValue(Topic.class, "endpoint").orElse("");
+                String endpoint = method.stringValue(Topic.class, "endpoint").orElse(pubSubConfigurationProperties.getTopicEndpoint());
                 String configurationName = method.stringValue(Topic.class, "configuration").orElse("");
                 String contentType = method.stringValue(Topic.class, "contentType").orElse(MediaType.APPLICATION_JSON);
                 ProjectTopicName projectTopicName = PubSubTopicUtils.toProjectTopicName(topic, projectId);

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/configuration/PubSubConfigurationSpec.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/configuration/PubSubConfigurationSpec.groovy
@@ -11,11 +11,14 @@ class PubSubConfigurationSpec extends Specification {
 
     void "test configuration binding"() {
         ApplicationContext ctx = ApplicationContext.run([
-                "gcp.pubsub.keepAliveIntervalMinutes" : "10"])
+                "gcp.pubsub.keepAliveIntervalMinutes" : "10",
+                "gcp.pubsub.topicEndpoint" : "us-central1-pubsub.googleapis.com:443",
+                ])
         PubSubConfigurationProperties properties = ctx.getBean(PubSubConfigurationProperties)
 
         expect:
         properties.keepAliveIntervalMinutes == 10
+        properties.topicEndpoint == "us-central1-pubsub.googleapis.com:443"
     }
 
     void "test publisher configuration binding"() {

--- a/src/main/docs/guide/pubsub/ordering.adoc
+++ b/src/main/docs/guide/pubsub/ordering.adoc
@@ -2,7 +2,7 @@
 
 Google Cloud Pub/Sub is a globally distributed event platform. When a client publishes a message, the platform stores the message on the nearest region to the publisher.
 Sometimes regulations such as GDPR impose restrictions on where customer data can live. When using Micronaut integration you can
-specify the endpoint of the topic so that Pub/Sub will persist the message data on the specified region.
+specify the endpoint of the topic, either via the topic annotation or properties, so that Pub/Sub will persist the message data on the specified region.
 To learn more about this feature visit the link:https://cloud.google.com/pubsub/docs/resource-location-restriction[resource location restriction] page.
 
 snippet::io.micronaut.gcp.pubsub.ordering.LocationClient[tags="imports, clazz", source="main"]


### PR DESCRIPTION
Default endpoint can now be specified via properties file (gcp.pubsub.topicEndpoint).
This is useful in scenarios where one have several topics that should all publish to the same endpoint (due to data locality such as GDPR) such that one don't need to specify the endpoint field on every topic annotation.

Solves #661 