### PR TITLE
Draft PR Issue 200

### DIFF
--- a/gcp-http-client/src/main/java/io/micronaut/gcp/http/client/GoogleFunctionAuthFilter.java
+++ b/gcp-http-client/src/main/java/io/micronaut/gcp/http/client/GoogleFunctionAuthFilter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gcp.http.client;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.annotation.Filter;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+
+/**
+ * A filter that allows function to function communication in GCP
+ * (https://cloud.google.com/functions/docs/securing/authenticating?authuser=1#function-to-function).
+ *
+ * Requires the user to set the {@code gcp.http.client.auth.function.patterns} property with the URI patterns
+ * to apply the filter to. For example {@code /**} for all requests.
+ *
+ * @author perrym
+ * @since 4.3.0
+ */
+@Requires(property = "gcp.http.client.auth.function.patterns")
+@Filter(patterns = "${gcp.http.client.auth.function.patterns:/**}")
+public class GoogleFunctionAuthFilter extends GoogleAuthFilter {
+
+    /**
+     * Default constructor.
+     */
+    public GoogleFunctionAuthFilter() {
+        super();
+    }
+
+    @Override
+    protected String encodeURI(MutableHttpRequest<?> request) throws UnsupportedEncodingException {
+        URI fullURI = request.getUri();
+        String receivingURI = fullURI.getScheme() + "://" + fullURI.getHost() + fullURI.getPath();
+        return AUDIENCE + URLEncoder.encode(receivingURI, "UTF-8");
+    }
+}

--- a/gcp-http-client/src/main/java/io/micronaut/gcp/http/client/GoogleServiceAuthFilter.java
+++ b/gcp-http-client/src/main/java/io/micronaut/gcp/http/client/GoogleServiceAuthFilter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gcp.http.client;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.annotation.Filter;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+
+/**
+ * A filter that allows service to service communication in GCP (https://cloud.google.com/run/docs/authenticating/service-to-service).
+ *
+ * Requires the user to set the {@code gcp.http.client.auth.service.patterns} property with the URI patterns
+ * to apply the filter to. For example {@code /**} for all requests.
+ *
+ * @author perrym
+ * @since 4.3.0
+ */
+@Requires(property = "gcp.http.client.auth.service.patterns")
+@Filter(patterns = "${gcp.http.client.auth.service.patterns:/**}")
+public class GoogleServiceAuthFilter extends GoogleAuthFilter {
+
+    /**
+     * Default constructor.
+     */
+    public GoogleServiceAuthFilter() {
+        super();
+    }
+
+    @Override
+    protected String encodeURI(MutableHttpRequest<?> request) throws UnsupportedEncodingException {
+        URI fullURI = request.getUri();
+        String receivingURI = fullURI.getScheme() + "://" + fullURI.getHost();
+        return AUDIENCE + URLEncoder.encode(receivingURI, "UTF-8");
+    }
+}

--- a/gcp-http-client/src/test/groovy/io/micronaut/gcp/http/client/GoogleFunctionAuthFilterSpec.groovy
+++ b/gcp-http-client/src/test/groovy/io/micronaut/gcp/http/client/GoogleFunctionAuthFilterSpec.groovy
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gcp.http.client
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.env.Environment
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientException
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(environments = Environment.GOOGLE_COMPUTE)
+@Property(name = "gcp.http.client.auth.function.patterns", value = "/test/**")
+class GoogleFunctionAuthFilterSpec extends Specification {
+
+    @Inject
+    TestClient client
+
+    void 'test apply auth to requests'() {
+        when:
+        def result = client.home()
+
+        then:
+        result == 'good'
+
+        when:
+        client.applyToMe()
+
+        then:
+        def e = thrown(HttpClientException)
+        e.message.contains('metadata: nodename nor servname provided') || e.message.contains('metadata: Temporary failure in name resolution') || e.message.contains('metadata: Name or service not known') || e.message.contains('No such host is known (metadata')
+    }
+
+
+    @Client("/")
+    static interface TestClient {
+        @Get("/")
+        String home()
+
+        @Get("/test/foo")
+        String applyToMe()
+    }
+
+    @Controller("/")
+    static class TestController {
+        @Get("/")
+        String home() {
+            return "good"
+        }
+
+        @Get("/test/foo")
+        String applyToMe() {
+            return "ok"
+        }
+    }
+}

--- a/gcp-http-client/src/test/groovy/io/micronaut/gcp/http/client/GoogleServiceAuthFilterSpec.groovy
+++ b/gcp-http-client/src/test/groovy/io/micronaut/gcp/http/client/GoogleServiceAuthFilterSpec.groovy
@@ -27,8 +27,8 @@ import spock.lang.Specification
 import jakarta.inject.Inject
 
 @MicronautTest(environments = Environment.GOOGLE_COMPUTE)
-@Property(name = "gcp.http.client.auth.patterns", value = "/test/**")
-class GoogleAuthFilterSpec extends Specification {
+@Property(name = "gcp.http.client.auth.service.patterns", value = "/test/**")
+class GoogleServiceAuthFilterSpec extends Specification {
 
     @Inject
     TestClient client

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
-projectVersion=4.2.1-SNAPSHOT
+projectVersion=4.3.0-SNAPSHOT
 projectGroup=io.micronaut.gcp
 
 micronautDocsVersion=2.0.0
 micronautTestVersion=3.1.1
-micronautVersion=3.4.2
+micronautVersion=3.5.2
 
 googleAuthLibraryOauth2HttpVersion=1.5.3
 googleCloudCoreVersion=2.5.6
@@ -13,7 +13,7 @@ googleCloudSecretmanagerVersion=2.1.3
 googleCloudNativeImageSupportVersion=0.14.1
 
 groovyVersion=3.0.10
-spockVersion=2.0-groovy-3.0
+spockVersion=2.1-groovy-3.0
 
 title=Micronaut GCP
 projectDesc=Provides integration between Micronaut and Google Cloud Platform (GCP)
@@ -21,7 +21,7 @@ projectUrl=https://micronaut.io
 githubSlug=micronaut-projects/micronaut-gcp
 developers=Graeme Rocher
 
-githubCoreBranch=3.5.x
+githubCoreBranch=3.6.x
 bomProperty=micronautGcpVersion
 
 org.gradle.caching=true


### PR DESCRIPTION
Draft PR for Issue 200 (google auth cloud functions defect)

Added GoogleFunctionAuthFilter and GoogleServiceAuthFilter, which both extend the original GoogleAuthFilter class. Each override the encodeURI function to set the receivingURI as required for that type of gcp service/function, and each is only created if their unique property patterns path is set.