### PR TITLE
Google credentials opt-out

### DIFF
--- a/gcp-common/src/main/java/io/micronaut/gcp/credentials/GoogleCredentialsConfiguration.java
+++ b/gcp-common/src/main/java/io/micronaut/gcp/credentials/GoogleCredentialsConfiguration.java
@@ -18,6 +18,7 @@ package io.micronaut.gcp.credentials;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.Context;
+import io.micronaut.core.util.Toggleable;
 import io.micronaut.gcp.GoogleCloudConfiguration;
 
 import io.micronaut.core.annotation.NonNull;
@@ -37,7 +38,15 @@ import java.util.Optional;
 @ConfigurationProperties(GoogleCredentialsConfiguration.PREFIX)
 @Context
 @BootstrapContextCompatible
-public class GoogleCredentialsConfiguration {
+public class GoogleCredentialsConfiguration implements Toggleable {
+
+    /**
+     * Google credentials configuration is enabled by default.
+     *
+     * @see GoogleCredentialsFactory#defaultGoogleCredentials()
+     */
+    public static final boolean DEFAULT_ENABLED = true;
+
     /**
      * The default scopes.
      */
@@ -47,6 +56,8 @@ public class GoogleCredentialsConfiguration {
      * The prefix to use.
      */
     public static final String PREFIX = GoogleCloudConfiguration.PREFIX + ".credentials";
+
+    private boolean enabled = DEFAULT_ENABLED;
 
     private List<URI> scopes = DEFAULT_SCOPES;
 
@@ -74,7 +85,7 @@ public class GoogleCredentialsConfiguration {
     }
 
     /**
-     * The location of the service account credential key file. 
+     * The location of the service account credential key file.
      * See <a href="https://cloud.google.com/iam/docs/understanding-service-accounts">Understanding Service Accounts</a>
      * for more information on generating a service account key file.
      * @return The location
@@ -106,5 +117,25 @@ public class GoogleCredentialsConfiguration {
      */
     public void setEncodedKey(@Nullable String encodedKey) {
         this.encodedKey = encodedKey;
+    }
+
+    /**
+     * Returns whether Google credentials configuration is enabled or not.
+     * @since 4.4.1
+     */
+    @Override
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+
+    /**
+     * Allows disabling Google credentials configuration. This may be useful in situations where
+     * you don't want to authenticate despite having the Google Cloud SDK configured. Default value
+     * is {@value #DEFAULT_ENABLED}.
+     * @param enabled whether to enable or disable Google credentials configuration.
+     * @since 4.4.1
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 }

--- a/gcp-common/src/main/java/io/micronaut/gcp/credentials/GoogleCredentialsFactory.java
+++ b/gcp-common/src/main/java/io/micronaut/gcp/credentials/GoogleCredentialsFactory.java
@@ -22,6 +22,7 @@ import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.core.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,6 +85,7 @@ public class GoogleCredentialsFactory {
      */
     @Requires(missingBeans = GoogleCredentials.class)
     @Requires(classes = com.google.auth.oauth2.GoogleCredentials.class)
+    @Requires(property = GoogleCredentialsConfiguration.PREFIX + ".enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
     @Primary
     @Singleton
     protected GoogleCredentials defaultGoogleCredentials() throws IOException {

--- a/gcp-common/src/test/groovy/io/micronaut/gcp/credentials/GoogleCredentialsFactorySpec.groovy
+++ b/gcp-common/src/test/groovy/io/micronaut/gcp/credentials/GoogleCredentialsFactorySpec.groovy
@@ -1,0 +1,22 @@
+package io.micronaut.gcp.credentials
+
+import com.google.auth.oauth2.GoogleCredentials
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.exceptions.NoSuchBeanException
+import spock.lang.Specification
+
+class GoogleCredentialsFactorySpec extends Specification {
+
+    void "it can disable GoogleCredentials bean"() {
+        given:
+        def ctx = ApplicationContext.run([
+                (GoogleCredentialsConfiguration.PREFIX + ".enabled"): false
+        ])
+
+        when:
+        ctx.getBean(GoogleCredentials)
+
+        then:
+        thrown(NoSuchBeanException)
+    }
+}


### PR DESCRIPTION
Allows disabling Google credentials configuration. This may be useful in situations where you don't want to authenticate despite having the Google Cloud SDK configured.