### PR TITLE
allow audience configuration per service

### DIFF
--- a/gcp-http-client/src/main/java/io/micronaut/gcp/http/client/GoogleAuthFilter.java
+++ b/gcp-http-client/src/main/java/io/micronaut/gcp/http/client/GoogleAuthFilter.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.gcp.http.client;
 
+import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.http.HttpRequest;
@@ -25,6 +26,7 @@ import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.exceptions.HttpClientException;
 import io.micronaut.http.filter.ClientFilterChain;
 import io.micronaut.http.filter.HttpClientFilter;
+import io.micronaut.inject.qualifiers.Qualifiers;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -35,6 +37,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.util.Optional;
 
 /**
  * A filter that allows service to service communication in GCP (https://cloud.google.com/run/docs/authenticating/service-to-service).
@@ -49,15 +52,15 @@ import java.net.URLEncoder;
 @Requires(property = "gcp.http.client.auth.patterns")
 @Filter(patterns = "${gcp.http.client.auth.patterns:/**}")
 public class GoogleAuthFilter implements HttpClientFilter, AutoCloseable {
+
     private static final String METADATA_FLAVOR = "Metadata-Flavor";
     private static final String GOOGLE = "Google";
-    private static final String AUDIENCE = "/computeMetadata/v1/instance/service-accounts/default/identity?audience=";
+    private static final String IDENTITY_TOKEN_URI = "/computeMetadata/v1/instance/service-accounts/default/identity?audience=";
     private final HttpClient authClient;
+    private final ApplicationContext applicationContext;
 
-    /**
-     * Default constructor.
-     */
-    public GoogleAuthFilter() {
+    public GoogleAuthFilter(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
         try {
             this.authClient = HttpClient.create(new URL("http://metadata"));
         } catch (MalformedURLException e) {
@@ -67,10 +70,10 @@ public class GoogleAuthFilter implements HttpClientFilter, AutoCloseable {
 
     @Override
     public Publisher<? extends HttpResponse<?>> doFilter(MutableHttpRequest<?> request, ClientFilterChain chain) {
-        Flux<String> token = Mono.fromCallable(() -> encodeURI(request))
-                .flatMapMany(authURI -> authClient.retrieve(HttpRequest.GET(authURI).header(
-                        METADATA_FLAVOR, GOOGLE
-                )));
+        Flux<String> token = Mono.fromCallable(() -> encodeIdentityTokenURI(request))
+                                 .flatMapMany(authURI -> authClient.retrieve(HttpRequest.GET(authURI).header(
+                                     METADATA_FLAVOR, GOOGLE
+                                 )));
 
         return token.flatMap(t -> chain.proceed(request.bearerAuth(t)));
     }
@@ -81,9 +84,26 @@ public class GoogleAuthFilter implements HttpClientFilter, AutoCloseable {
         authClient.close();
     }
 
-    private String encodeURI(MutableHttpRequest<?> request) throws UnsupportedEncodingException {
+    private String encodeIdentityTokenURI(MutableHttpRequest<?> request) throws UnsupportedEncodingException {
+        return IDENTITY_TOKEN_URI + URLEncoder.encode(getAudience(request), "UTF-8");
+    }
+
+    private String getAudience(MutableHttpRequest<?> request) {
+        final Optional<Object> serviceId = request.getAttribute("micronaut.http.serviceId");
+
+        if (serviceId.isPresent()) {
+            final Optional<GoogleAuthServiceConfig> config = applicationContext.findBean(GoogleAuthServiceConfig.class, Qualifiers.byName(serviceId.get().toString()));
+
+            if (config.isPresent()) {
+                return config.get().getAudience();
+            }
+        }
+
+        return getAudienceFromRequest(request);
+    }
+
+    private String getAudienceFromRequest(final MutableHttpRequest<?> request) {
         URI fullURI = request.getUri();
-        String receivingURI = fullURI.getScheme() + "://" + fullURI.getHost();
-        return AUDIENCE + URLEncoder.encode(receivingURI, "UTF-8");
+        return fullURI.getScheme() + "://" + fullURI.getHost();
     }
 }

--- a/gcp-http-client/src/main/java/io/micronaut/gcp/http/client/GoogleAuthServiceConfig.java
+++ b/gcp-http-client/src/main/java/io/micronaut/gcp/http/client/GoogleAuthServiceConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gcp.http.client;
+
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+
+/**
+ * Creates a GoogleAuthServiceConfig for each Service configured under
+ * gcp.http.client.auth.services.*.audience. The audience can be configured per
+ * service and the correct config bean is selected in {@code GoogleAuthFilter} via the service id
+ * inside the corresponding request.
+ *
+ * Requires the user to set the {@code gcp.http.client.auth.services.*.audience} property with the
+ * desired audience to create the corresponding config bean.
+ *
+ * @author kgreulich
+ * @since 1.0.0
+ */
+@EachProperty(GoogleAuthServiceConfig.PREFIX)
+public class GoogleAuthServiceConfig {
+
+    public static final String PREFIX = "gcp.http.client.auth.services";
+    private final String serviceId;
+
+    private String audience;
+
+    public GoogleAuthServiceConfig(
+        @Parameter String serviceId
+    ) {
+        this.serviceId = serviceId;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public String getAudience() {
+        return audience;
+    }
+
+    public void setAudience(final String audience) {
+        this.audience = audience;
+    }
+}


### PR DESCRIPTION
Allowing audience configuration per service. 

```
gcp:
  http:
    client:
      auth:
        services:
          test-service
            audience: "audience.com"
```