### PR TITLE
CI: resolve checkstyle error

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['11', '17']
+        java: ['17']
         graalvm: ['latest', 'dev']
     steps:
        # https://github.com/actions/virtual-environments/issues/709

--- a/gcp-http-client/src/main/java/io/micronaut/gcp/http/client/GoogleAuthServiceConfig.java
+++ b/gcp-http-client/src/main/java/io/micronaut/gcp/http/client/GoogleAuthServiceConfig.java
@@ -44,14 +44,23 @@ public class GoogleAuthServiceConfig {
         this.serviceId = serviceId;
     }
 
+    /**
+     * @return the audience service identifier
+     */
     public String getServiceId() {
         return serviceId;
     }
 
+    /**
+     * @return the desired audience
+     */
     public String getAudience() {
         return audience;
     }
 
+    /**
+     * @param audience set the desired audience
+     */
     public void setAudience(final String audience) {
         this.audience = audience;
     }


### PR DESCRIPTION
#693 added `GoogleAuthServiceConfig` class without javadoc for public API, resulting in checkstyle errors that fail CI builds.

#666 depends on this PR to build successfully

ping @kgreulich 