### PR TITLE
Add TCK tests for gcp-function-http

### DIFF
--- a/gcp-function-http-test/build.gradle
+++ b/gcp-function-http-test/build.gradle
@@ -8,7 +8,9 @@ dependencies {
     api project(":gcp-function-http")
 
     implementation(mn.micronaut.servlet.core)
-    implementation(libs.jetty.servlet)
+    implementation(libs.jetty.servlet) {
+        exclude(group: "org.slf4j") // Jetty pulls in 2.0.0 of SLF4j which needs to wait for Micronaut 4.0.0
+    }
 
     testAnnotationProcessor(mn.micronaut.inject.java)
 

--- a/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/HttpFunction.java
+++ b/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/HttpFunction.java
@@ -63,7 +63,11 @@ public class HttpFunction extends FunctionInitializer implements com.google.clou
      * Default constructor.
      */
     public HttpFunction() {
-        this.httpHandler = new ServletHttpHandler<HttpRequest, HttpResponse>(applicationContext) {
+        httpHandler = initializeHandler();
+    }
+
+    private ServletHttpHandler<HttpRequest, HttpResponse> initializeHandler() {
+        final ServletHttpHandler<HttpRequest, HttpResponse> httpHandler = new ServletHttpHandler<HttpRequest, HttpResponse>(applicationContext) {
             @Override
             protected ServletExchange<HttpRequest, HttpResponse> createExchange(HttpRequest request, HttpResponse response) {
                 final GoogleFunctionHttpResponse<Object> res =
@@ -84,6 +88,12 @@ public class HttpFunction extends FunctionInitializer implements com.google.clou
         Runtime.getRuntime().addShutdownHook(
                 new Thread(httpHandler::close)
         );
+        return httpHandler;
+    }
+
+    public HttpFunction(ApplicationContext context) {
+        super(context);
+        httpHandler = initializeHandler();
     }
 
     @Override

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("io.micronaut.build.shared.settings") version "5.4.4"
+    id("io.micronaut.build.shared.settings") version "5.4.7"
 }
 
 enableFeaturePreview('TYPESAFE_PROJECT_ACCESSORS')

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,6 +29,7 @@ include 'gcp-serde-cloudevents'
 include 'test-suite'
 include 'test-suite-groovy'
 include 'test-suite-http-server-tck-gcp-function-http'
+include 'test-suite-http-server-tck-gcp-function-http-test'
 include 'test-suite-kotlin'
 
 micronautBuild {

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("io.micronaut.build.shared.settings") version "5.4.7"
+    id("io.micronaut.build.shared.settings") version "5.4.8"
 }
 
 enableFeaturePreview('TYPESAFE_PROJECT_ACCESSORS')

--- a/test-suite-http-server-tck-gcp-function-http-test/build.gradle.kts
+++ b/test-suite-http-server-tck-gcp-function-http-test/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 dependencies {
     testImplementation(projects.gcpFunctionHttp)
-    testImplementation(libs.managed.functions.framework.api)
+    testImplementation(projects.gcpFunctionHttpTest)
 }

--- a/test-suite-http-server-tck-gcp-function-http-test/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpTestServerUnderTest.java
+++ b/test-suite-http-server-tck-gcp-function-http-test/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpTestServerUnderTest.java
@@ -1,0 +1,74 @@
+package io.micronaut.http.server.tck.gcp.function;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.gcp.function.http.test.InvokerHttpServer;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.server.tck.ServerUnderTest;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+@SuppressWarnings("java:S2187") // Suppress because despite its name, this is not a Test
+public class GcpFunctionHttpTestServerUnderTest implements ServerUnderTest {
+
+    private final InvokerHttpServer server;
+    private HttpClient httpClient;
+    private BlockingHttpClient client;
+
+    public GcpFunctionHttpTestServerUnderTest(Map<String, Object> properties) {
+        server = ApplicationContext.run(InvokerHttpServer.class, properties);
+    }
+
+    @Override
+    public <I, O> HttpResponse<O> exchange(HttpRequest<I> request, Argument<O> bodyType) {
+        return getBlockingHttpClient().exchange(request, bodyType);
+    }
+
+    @Override
+    public <I, O> HttpResponse<O> exchange(HttpRequest<I> request) {
+        return getBlockingHttpClient().exchange(request);
+    }
+
+    @Override
+    public <I, O> HttpResponse<O> exchange(HttpRequest<I> request, Class<O> bodyType) {
+        return getBlockingHttpClient().exchange(request, bodyType);
+    }
+
+    @Override
+    public ApplicationContext getApplicationContext() {
+        return server.getApplicationContext();
+    }
+
+    @Override
+    public void close() throws IOException {
+        server.close();
+    }
+
+    @Override
+    @NonNull
+    public Optional<Integer> getPort() {
+        return Optional.of(server.getPort());
+    }
+
+    @NonNull
+    private HttpClient getHttpClient() {
+        if (httpClient == null) {
+            this.httpClient = getApplicationContext().createBean(HttpClient.class, server.getURL());
+        }
+        return httpClient;
+    }
+
+    @NonNull
+    private BlockingHttpClient getBlockingHttpClient() {
+        if (client == null) {
+            this.client = getHttpClient().toBlocking();
+        }
+        return client;
+    }
+}

--- a/test-suite-http-server-tck-gcp-function-http-test/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpTestServerUnderTestProvider.java
+++ b/test-suite-http-server-tck-gcp-function-http-test/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpTestServerUnderTestProvider.java
@@ -1,0 +1,16 @@
+package io.micronaut.http.server.tck.gcp.function;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.http.server.tck.ServerUnderTest;
+import io.micronaut.http.server.tck.ServerUnderTestProvider;
+
+import java.util.Map;
+
+public class GcpFunctionHttpTestServerUnderTestProvider implements ServerUnderTestProvider {
+
+    @NonNull
+    @Override
+    public ServerUnderTest getServer(Map<String, Object> properties) {
+        return new GcpFunctionHttpTestServerUnderTest(properties);
+    }
+}

--- a/test-suite-http-server-tck-gcp-function-http-test/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-gcp-function-http-test/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpHttpServerTestSuite.java
@@ -7,7 +7,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 
 @Suite
 @SelectPackages("io.micronaut.http.server.tck.tests")
-@SuiteDisplayName("HTTP Server TCK for Azure Functions")
+@SuiteDisplayName("HTTP Server TCK for GCP Function HTTP Test")
 @ExcludeClassNamePatterns({
     "io.micronaut.http.server.tck.tests.MiscTest", // Fails when there's no Body annotation
     "io.micronaut.http.server.tck.tests.filter.HttpServerFilterTest",

--- a/test-suite-http-server-tck-gcp-function-http-test/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-gcp-function-http-test/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpHttpServerTestSuite.java
@@ -1,0 +1,17 @@
+package io.micronaut.http.server.tck.gcp.function.tests;
+
+import org.junit.platform.suite.api.ExcludeClassNamePatterns;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
+
+@Suite
+@SelectPackages("io.micronaut.http.server.tck.tests")
+@SuiteDisplayName("HTTP Server TCK for Azure Functions")
+@ExcludeClassNamePatterns({
+    "io.micronaut.http.server.tck.tests.MiscTest", // Fails when there's no Body annotation
+    "io.micronaut.http.server.tck.tests.filter.HttpServerFilterTest",
+    "io.micronaut.http.server.tck.tests.FiltersTest",
+})
+class GcpFunctionHttpHttpServerTestSuite {
+}

--- a/test-suite-http-server-tck-gcp-function-http-test/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpTestServerTestSuite.java
+++ b/test-suite-http-server-tck-gcp-function-http-test/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpTestServerTestSuite.java
@@ -13,5 +13,5 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.filter.HttpServerFilterTest",
     "io.micronaut.http.server.tck.tests.FiltersTest",
 })
-class GcpFunctionHttpHttpServerTestSuite {
+class GcpFunctionHttpTestServerTestSuite {
 }

--- a/test-suite-http-server-tck-gcp-function-http-test/src/test/resources/META-INF/services/io.micronaut.http.server.tck.ServerUnderTestProvider
+++ b/test-suite-http-server-tck-gcp-function-http-test/src/test/resources/META-INF/services/io.micronaut.http.server.tck.ServerUnderTestProvider
@@ -1,0 +1,1 @@
+io.micronaut.http.server.tck.gcp.function.GcpFunctionHttpTestServerUnderTestProvider

--- a/test-suite-http-server-tck-gcp-function-http-test/src/test/resources/logback.xml
+++ b/test-suite-http-server-tck-gcp-function-http-test/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpServerUnderTest.java
+++ b/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpServerUnderTest.java
@@ -28,17 +28,12 @@ public class GcpFunctionHttpServerUnderTest implements ServerUnderTest {
             .properties(properties)
             .deduceEnvironment(false)
             .build();
-        ctx.start();
-        this.function = new HttpFunction(ctx);
+        this.function = new HttpFunction(ctx.start());
     }
 
     @Override
     public <I, O> HttpResponse<O> exchange(HttpRequest<I> request, Argument<O> bodyType) {
-        return adaptResponse(function.invoke(request), bodyType);
-    }
-
-    private <O> HttpResponse<O> adaptResponse(GoogleHttpResponse invoke, Argument<O> bodyType) {
-        return new HttpResponseAdaptor<>(invoke, bodyType);
+        return new HttpResponseAdaptor<>(function.invoke(request), bodyType);
     }
 
     @Override

--- a/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpServerUnderTest.java
+++ b/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpServerUnderTest.java
@@ -52,6 +52,13 @@ public class GcpFunctionHttpServerUnderTest implements ServerUnderTest {
         }
     }
 
+    @Override
+    @NonNull
+    public Optional<Integer> getPort() {
+        // This port is used in the CorsSimpleRequestTests
+        return Optional.of(1234);
+    }
+
     static class HttpResponseAdaptor<O> implements HttpResponse<O> {
 
         final GoogleHttpResponse googleHttpResponse;

--- a/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpServerUnderTest.java
+++ b/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpServerUnderTest.java
@@ -44,7 +44,7 @@ public class GcpFunctionHttpServerUnderTest implements ServerUnderTest {
 
     @Override
     public ApplicationContext getApplicationContext() {
-        return null;
+        return this.function.getApplicationContext();
     }
 
     @Override

--- a/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpServerUnderTest.java
+++ b/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpServerUnderTest.java
@@ -21,16 +21,14 @@ import java.util.Optional;
 @SuppressWarnings("java:S2187") // Suppress because despite its name, this is not a Test
 public class GcpFunctionHttpServerUnderTest implements ServerUnderTest {
 
-    private final ApplicationContext ctx;
     private final HttpFunction function;
 
     public GcpFunctionHttpServerUnderTest(Map<String, Object> properties) {
         properties.put("micronaut.server.context-path", "/");
-        this.ctx = ApplicationContext.builder(Environment.FUNCTION, Environment.GOOGLE_COMPUTE, Environment.TEST)
+        this.function = new HttpFunction(ApplicationContext.builder(Environment.FUNCTION, Environment.GOOGLE_COMPUTE, Environment.TEST)
             .properties(properties)
             .deduceEnvironment(false)
-            .build();
-        this.function = new HttpFunction(ctx.start());
+            .build());
     }
 
     @Override
@@ -51,9 +49,6 @@ public class GcpFunctionHttpServerUnderTest implements ServerUnderTest {
     public void close() throws IOException {
         if (function != null) {
             function.close();
-        }
-        if (ctx != null) {
-            ctx.close();
         }
     }
 

--- a/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpServerUnderTest.java
+++ b/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpServerUnderTest.java
@@ -28,7 +28,7 @@ public class GcpFunctionHttpServerUnderTest implements ServerUnderTest {
         this.function = new HttpFunction(ApplicationContext.builder(Environment.FUNCTION, Environment.GOOGLE_COMPUTE, Environment.TEST)
             .properties(properties)
             .deduceEnvironment(false)
-            .build());
+            .start());
     }
 
     @Override

--- a/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpServerUnderTest.java
+++ b/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpServerUnderTest.java
@@ -2,6 +2,7 @@ package io.micronaut.http.server.tck.gcp.function;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.type.Argument;
 import io.micronaut.gcp.function.http.GoogleHttpResponse;
@@ -67,16 +68,19 @@ public class GcpFunctionHttpServerUnderTest implements ServerUnderTest {
         }
 
         @Override
+        @NonNull
         public HttpHeaders getHeaders() {
             return googleHttpResponse.getHttpHeaders();
         }
 
         @Override
+        @NonNull
         public MutableConvertibleValues<Object> getAttributes() {
             return null;
         }
 
         @Override
+        @NonNull
         public Optional<O> getBody() {
             return googleHttpResponse.getBody(bodyType);
         }

--- a/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpServerUnderTest.java
+++ b/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpServerUnderTest.java
@@ -82,6 +82,9 @@ public class GcpFunctionHttpServerUnderTest implements ServerUnderTest {
         @Override
         @NonNull
         public Optional<O> getBody() {
+            if (bodyType.isAssignableFrom(String.class)) {
+                return (Optional<O>) Optional.of(googleHttpResponse.getBodyAsText());
+            }
             return googleHttpResponse.getBody(bodyType);
         }
     }

--- a/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpHttpServerTestSuite.java
@@ -7,11 +7,11 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 
 @Suite
 @SelectPackages("io.micronaut.http.server.tck.tests")
-@SuiteDisplayName("HTTP Server TCK for Azure Functions")
 @ExcludeClassNamePatterns({
     "io.micronaut.http.server.tck.tests.MiscTest", // Fails when there's no Body annotation
     "io.micronaut.http.server.tck.tests.filter.HttpServerFilterTest",
     "io.micronaut.http.server.tck.tests.FiltersTest",
 })
+@SuiteDisplayName("HTTP Server TCK for for GCP Function HTTP")
 class GcpFunctionHttpHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpHttpServerTestSuite.java
@@ -7,11 +7,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 
 @Suite
 @SelectPackages("io.micronaut.http.server.tck.tests")
-@ExcludeClassNamePatterns({
-    "io.micronaut.http.server.tck.tests.MiscTest", // Fails when there's no Body annotation
-    "io.micronaut.http.server.tck.tests.filter.HttpServerFilterTest",
-    "io.micronaut.http.server.tck.tests.FiltersTest",
-})
 @SuiteDisplayName("HTTP Server TCK for for GCP Function HTTP")
 class GcpFunctionHttpHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpServerTestSuite.java
@@ -1,6 +1,7 @@
 package io.micronaut.http.server.tck.gcp.function.tests;
 
 import org.junit.platform.suite.api.ExcludeClassNamePatterns;
+import org.junit.platform.suite.api.IncludeClassNamePatterns;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SuiteDisplayName;
@@ -8,5 +9,16 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @Suite
 @SelectPackages("io.micronaut.http.server.tck.tests")
 @SuiteDisplayName("HTTP Server TCK for for GCP Function HTTP")
+@ExcludeClassNamePatterns(
+    {
+        "io.micronaut.http.server.tck.tests.CookiesTest",
+        "io.micronaut.http.server.tck.tests.ConsumesTest",
+        "io.micronaut.http.server.tck.tests.filter.HttpServerFilterTest",
+        "io.micronaut.http.server.tck.tests.BodyTest",
+        "io.micronaut.http.server.tck.tests.MiscTest",
+        "io.micronaut.http.server.tck.tests.OctetTest",
+        "io.micronaut.http.server.tck.tests.ErrorHandlerTest"
+    }
+)
 class GcpFunctionHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpServerTestSuite.java
@@ -8,5 +8,5 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @Suite
 @SelectPackages("io.micronaut.http.server.tck.tests")
 @SuiteDisplayName("HTTP Server TCK for for GCP Function HTTP")
-class GcpFunctionHttpHttpServerTestSuite {
+class GcpFunctionHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-gcp-function-http/src/test/resources/logback.xml
+++ b/test-suite-http-server-tck-gcp-function-http/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
In https://github.com/micronaut-projects/micronaut-gcp/pull/777 we added a TCK test for gcp-function-http-test

This adds one for gcp-function-http