### PR TITLE
Fix MissingBodyAnnotationTest

### DIFF
--- a/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/BodyUtils.java
+++ b/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/BodyUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gcp.function.http;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.http.MediaType;
+import io.micronaut.json.JsonMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Utility class to provide conversion for HTTP request body.
+ *
+ * @author Sergio del Amo
+ * @since 4.0.0
+ */
+@Internal
+public final class BodyUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BodyUtils.class);
+
+    private BodyUtils() {
+    }
+
+    @NonNull
+    public static Optional<byte[]> bodyAsByteArray(@NonNull JsonMapper jsonMapper,
+                                                   @NonNull Supplier<MediaType> contentTypeSupplier,
+                                                   @NonNull Supplier<Charset> characterEncodingSupplier,
+                                                   @NonNull Supplier<Object> bodySupplier) {
+        Object body = bodySupplier.get();
+        if (body == null) {
+            return Optional.empty();
+        }
+
+        MediaType mediaType = contentTypeSupplier.get();
+        boolean mapFromJson = mediaType == null || mediaType.equals(MediaType.APPLICATION_JSON_TYPE);
+
+        if (body instanceof CharSequence) {
+            return Optional.of(body.toString().getBytes(characterEncodingSupplier.get()));
+        } else if (body instanceof byte[] bytes) {
+            return Optional.of(bytes);
+        } else if (mapFromJson) {
+            try {
+                return Optional.of(jsonMapper.writeValueAsBytes(body));
+            } catch (IOException e) {
+                LOG.error("IOException writing body to JSON String", e);
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpServerTestSuite.java
@@ -25,7 +25,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.cors.SimpleRequestWithCorsNotEnabledTest", // Multiple routes are selected
     "io.micronaut.http.server.tck.tests.codec.JsonCodecAdditionalTypeTest", // https://github.com/micronaut-projects/micronaut-core/pull/9308
     "io.micronaut.http.server.tck.tests.StreamTest", // Fails in Servlet https://github.com/micronaut-projects/micronaut-servlet/pull/482
-    "io.micronaut.http.server.tck.tests.MissingBodyAnnotationTest",
     "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest" // Broken in servlet
 })
 class GcpFunctionHttpServerTestSuite {


### PR DESCRIPTION
The test in MissingBodyAnnotationTest has a request with a POJO as a body and no content type.

When converting this to a Google Request prior to this PR we were simply calling toString() on the POJO, which resulted in an invalid body in the Google request.

This PR attempts to convert the body to a usable form instead.

I think this is ok, but I am only about 90% sure this is the correct fix, as it differs from the AWS solution for the same issue, so I worry that toGoogleRequest is used elsewhere in the stack.

In AWS it's only used in testing