### PR TITLE
Correctly lookup project from @PubSubClient annotation

### DIFF
--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/intercept/PubSubClientIntroductionAdvice.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/intercept/PubSubClientIntroductionAdvice.java
@@ -99,7 +99,7 @@ public class PubSubClientIntroductionAdvice implements MethodInterceptor<Object,
         if (context.hasAnnotation(Topic.class)) {
 
             PubSubPublisherState publisherState = publisherStateCache.computeIfAbsent(context.getExecutableMethod(), method -> {
-                String projectId = method.stringValue(PubSubClient.class).orElse(googleCloudConfiguration.getProjectId());
+                String projectId = method.stringValue(PubSubClient.class, "project").orElse(googleCloudConfiguration.getProjectId());
                 Optional<Argument> orderingArgument = Arrays.stream(method.getArguments()).filter(argument -> argument.getAnnotationMetadata().hasAnnotation(OrderingKey.class)).findFirst();
                 String topic = method.stringValue(Topic.class).orElse(context.getName());
                 String endpoint = method.stringValue(Topic.class, "endpoint").orElse(pubSubConfigurationProperties.getTopicEndpoint());

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/DataHolder.java
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/DataHolder.java
@@ -7,6 +7,7 @@ public class DataHolder {
     private DataHolder() { }
 
     private Object data;
+    private String projectId;
 
     synchronized public static DataHolder getInstance() {
         if (instance == null) {
@@ -19,7 +20,16 @@ public class DataHolder {
         return data;
     }
 
+    public String getProjectId() {
+        return projectId;
+    }
+
     public void setData(Object data) {
         this.data = data;
+    }
+
+    public DataHolder setProjectId(String projectId) {
+        this.projectId = projectId;
+        return this;
     }
 }

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/support/PublisherIntroductionAdviceSpec.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/support/PublisherIntroductionAdviceSpec.groovy
@@ -30,6 +30,9 @@ class PublisherIntroductionAdviceSpec extends AbstractPublisherSpec {
     TestPubSubClient pubSubClient
 
     @Inject
+    TestPubSubClientWithProjectId pubSubClientWithProjectId
+
+    @Inject
     JsonMapper objectMapper
 
     void "client without annotation invoked"() {
@@ -66,6 +69,13 @@ class PublisherIntroductionAdviceSpec extends AbstractPublisherSpec {
         person.name = "alf"
         expect:
             pubSubClient.sendAndWait(person) == "1234"
+            DataHolder.instance.projectId == 'test-project'
+    }
+
+    void "publish using a client with a different project id"() {
+        expect:
+        pubSubClientWithProjectId.sendAndWait("hello") == "1234"
+        DataHolder.instance.projectId == 'a-different-project'
     }
 
     void "reactive publish with valid return"() {
@@ -100,6 +110,14 @@ interface TestPubSubClient {
     @MessageHeaders(  @MessageHeader(name = "x-header-added", value = "foo")  )
     String withExtraHeaders(Object data)
 
+}
+
+@PubSubClient(project = "a-different-project")
+@Requires(property = "spec.name", value = "PublisherIntroductionAdviceSpec")
+interface TestPubSubClientWithProjectId {
+
+    @Topic(value = "testTopic", contentType = "application/json")
+    String sendAndWait(Object data)
 }
 
 @Serdeable


### PR DESCRIPTION
Sorry there is no test attached, I had a quick look at the testing suite but didn't immediately see how to add a test for this. No usages of it even show up in my IDE to use as a guide.

I doubt the property is heavily used, and perhaps the better approach is to take it from the topic name as seen in the Resource Naming section here - https://micronaut-projects.github.io/micronaut-gcp/latest/guide/#producer