### PR TITLE
fix: close server application context

### DIFF
--- a/gcp-function-http-test/src/main/java/io/micronaut/gcp/function/http/test/InvokerHttpServer.java
+++ b/gcp-function-http-test/src/main/java/io/micronaut/gcp/function/http/test/InvokerHttpServer.java
@@ -167,6 +167,7 @@ public class InvokerHttpServer implements EmbeddedServer {
     public EmbeddedServer stop() {
         if (running.compareAndSet(true, false)) {
             try {
+                applicationContext.close();
                 server.stop();
             } catch (Exception e) {
                 if (LOGGER.isWarnEnabled()) {

--- a/test-suite-http-server-tck-gcp-function-http-test/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpTestServerUnderTest.java
+++ b/test-suite-http-server-tck-gcp-function-http-test/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpTestServerUnderTest.java
@@ -54,6 +54,7 @@ public class GcpFunctionHttpTestServerUnderTest implements ServerUnderTest {
 
     @Override
     public void close() throws IOException {
+        server.getApplicationContext().close();
         server.close();
     }
 

--- a/test-suite-http-server-tck-gcp-function-http-test/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpTestServerUnderTest.java
+++ b/test-suite-http-server-tck-gcp-function-http-test/src/test/java/io/micronaut/http/server/tck/gcp/function/GcpFunctionHttpTestServerUnderTest.java
@@ -54,7 +54,6 @@ public class GcpFunctionHttpTestServerUnderTest implements ServerUnderTest {
 
     @Override
     public void close() throws IOException {
-        server.getApplicationContext().close();
         server.close();
     }
 


### PR DESCRIPTION
without it:

 ./gradlew :test-suite-http-server-tck-gcp-function-http-test:test --parallel --rerun-tasks --no-daemon --no-build-cache

```
           Caused by:
                io.netty.channel.ChannelException: failed to open a new selector
                    at app//io.netty.channel.nio.NioEventLoop.openSelector(NioEventLoop.java:179)
                    at app//io.netty.channel.nio.NioEventLoop.<init>(NioEventLoop.java:146)
                    at app//io.netty.channel.nio.NioEventLoopGroup.newChild(NioEventLoopGroup.java:183)
                    at app//io.netty.channel.nio.NioEventLoopGroup.newChild(NioEventLoopGroup.java:38)
                    at app//io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:84)
                    ... 47 more

                    Caused by:
                    java.io.IOException: Too many open files
                        at java.base/sun.nio.ch.IOUtil.makePipe(Native Method)
                        at java.base/sun.nio.ch.KQueueSelectorImpl.<init>(KQueueSelectorImpl.java:86)
                        at java.base/sun.nio.ch.KQueueSelectorProvider.openSelector(KQueueSelectorProvider.java:36)
                        at io.netty.channel.nio.NioEventLoop.openSelector(NioEventLoop.java:177)
                        ... 51 more
```