### PR TITLE
Automatically nack messages in default exception handler.

### DIFF
--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/exception/PubSubMessageReceiverException.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/exception/PubSubMessageReceiverException.java
@@ -29,6 +29,19 @@ public class PubSubMessageReceiverException extends MessageListenerException {
 
     private final boolean autoAcknowledge;
 
+    /**
+     * Constructor for PubSubMessageReceiverException.
+     *
+     * @deprecated
+     * This exception is expected to only ever be created internally by the framework, and this form is no longer used.
+     * <p> {@link #PubSubMessageReceiverException(String, Object, PubSubConsumerState, boolean)} is now used instead. Any outside appropriate usage of
+     * this class (such as in exception handler tests) should be updated accordingly.
+     *
+     * @param message the exception message
+     * @param bean the bean with the targeted {@link io.micronaut.gcp.pubsub.annotation.Subscription} method
+     * @param state the consumer state at the time of message reception
+     */
+    @Deprecated(since = "5.1.0")
     public PubSubMessageReceiverException(String message, Object bean, PubSubConsumerState state) {
         super(message);
         this.state = state;
@@ -36,6 +49,18 @@ public class PubSubMessageReceiverException extends MessageListenerException {
         this.autoAcknowledge = false;
     }
 
+    /**
+     * Constructor for PubSubMessageReceiverException.
+     *
+     * <p>This exception is expected to only ever be created internally by the framework.
+     *
+     * @param message the exception message
+     * @param bean the bean with the targeted {@link io.micronaut.gcp.pubsub.annotation.Subscription} method
+     * @param state the consumer state at the time of message reception
+     * @param autoAcknowledge whether the targeted {@link io.micronaut.gcp.pubsub.annotation.Subscription} method is set for auto acknowledgement.
+     *                        NOTE - custom exception handlers are responsible for handling acknowledgement on their own, regardless of the value
+     *                        of this property
+     */
     public PubSubMessageReceiverException(String message, Object bean, PubSubConsumerState state, boolean autoAcknowledge) {
         super(message);
         this.state = state;
@@ -43,6 +68,21 @@ public class PubSubMessageReceiverException extends MessageListenerException {
         this.autoAcknowledge = autoAcknowledge;
     }
 
+    /**
+     * Constructor for PubSubMessageReceiverException.
+     *
+     * @deprecated
+     * This exception is expected to only ever be created internally by the framework, and this form is no longer used.
+     *
+     * <p>{@link #PubSubMessageReceiverException(String, Throwable, Object, PubSubConsumerState, boolean)} is now used instead. Any outside appropriate usage of
+     * this class (such as in exception handler tests) should be updated accordingly.
+     *
+     * @param message the exception message
+     * @param cause the exception cause
+     * @param bean the bean with the targeted {@link io.micronaut.gcp.pubsub.annotation.Subscription} method
+     * @param state the consumer state at the time of message reception
+     */
+    @Deprecated(since = "5.1.0")
     public PubSubMessageReceiverException(String message, Throwable cause, Object bean, PubSubConsumerState state) {
         super(message, cause);
         this.state = state;
@@ -50,6 +90,19 @@ public class PubSubMessageReceiverException extends MessageListenerException {
         this.autoAcknowledge = false;
     }
 
+    /**
+     * Constructor for PubSubMessageReceiverException.
+     *
+     * <p>This exception is expected to only ever be created internally by the framework.
+     *
+     * @param message the exception message
+     * @param cause the exception cause
+     * @param bean the bean with the targeted {@link io.micronaut.gcp.pubsub.annotation.Subscription} method
+     * @param state the consumer state at the time of message reception
+     * @param autoAcknowledge whether the targeted {@link io.micronaut.gcp.pubsub.annotation.Subscription} method is set for auto acknowledgement.
+     *                        NOTE - custom exception handlers are responsible for handling acknowledgement on their own, regardless of the value
+     *                        of this property
+     */
     public PubSubMessageReceiverException(String message, Throwable cause, Object bean, PubSubConsumerState state, boolean autoAcknowledge) {
         super(message, cause);
         this.state = state;

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/exception/PubSubMessageReceiverException.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/exception/PubSubMessageReceiverException.java
@@ -27,16 +27,32 @@ public class PubSubMessageReceiverException extends MessageListenerException {
     private final PubSubConsumerState state;
     private final Object listener;
 
+    private boolean autoAcknowledge = true;
+
     public PubSubMessageReceiverException(String message, Object bean, PubSubConsumerState state) {
         super(message);
         this.state = state;
         this.listener = bean;
     }
 
+    public PubSubMessageReceiverException(String message, Object bean, PubSubConsumerState state, boolean autoAcknowledge) {
+        super(message);
+        this.state = state;
+        this.listener = bean;
+        this.autoAcknowledge = autoAcknowledge;
+    }
+
     public PubSubMessageReceiverException(String message, Throwable cause, Object bean, PubSubConsumerState state) {
         super(message, cause);
         this.state = state;
         this.listener = bean;
+    }
+
+    public PubSubMessageReceiverException(String message, Throwable cause, Object bean, PubSubConsumerState state, boolean autoAcknowledge) {
+        super(message, cause);
+        this.state = state;
+        this.listener = bean;
+        this.autoAcknowledge = autoAcknowledge;
     }
 
     /**
@@ -53,5 +69,13 @@ public class PubSubMessageReceiverException extends MessageListenerException {
      */
     public PubSubConsumerState getState() {
         return state;
+    }
+
+    /**
+     *
+     * @return whether the subscription is set to automatically acknowledge messages after processing
+     */
+    public boolean isAutoAcknowledge() {
+        return autoAcknowledge;
     }
 }

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/exception/PubSubMessageReceiverException.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/exception/PubSubMessageReceiverException.java
@@ -27,12 +27,13 @@ public class PubSubMessageReceiverException extends MessageListenerException {
     private final PubSubConsumerState state;
     private final Object listener;
 
-    private boolean autoAcknowledge = true;
+    private final boolean autoAcknowledge;
 
     public PubSubMessageReceiverException(String message, Object bean, PubSubConsumerState state) {
         super(message);
         this.state = state;
         this.listener = bean;
+        this.autoAcknowledge = false;
     }
 
     public PubSubMessageReceiverException(String message, Object bean, PubSubConsumerState state, boolean autoAcknowledge) {
@@ -46,6 +47,7 @@ public class PubSubMessageReceiverException extends MessageListenerException {
         super(message, cause);
         this.state = state;
         this.listener = bean;
+        this.autoAcknowledge = false;
     }
 
     public PubSubMessageReceiverException(String message, Throwable cause, Object bean, PubSubConsumerState state, boolean autoAcknowledge) {

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/exception/PubSubMessageReceiverExceptionHandler.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/exception/PubSubMessageReceiverExceptionHandler.java
@@ -20,6 +20,11 @@ import io.micronaut.core.exceptions.ExceptionHandler;
 /**
  * Marker interface that {@link io.micronaut.gcp.pubsub.annotation.PubSubListener} beans can implement
  * to handle exceptions.
+ *
+ * Implementations of this interface are responsible for deciding whether to ack/nack the message and should do so
+ * via the supplied {@link com.google.cloud.pubsub.v1.AckReplyConsumer} that can be retrieved via the exception's
+ * {@link io.micronaut.gcp.pubsub.bind.PubSubConsumerState}.
+ *
  * @author Vinicius Carvalho
  * @since 2.0.0
  */

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/intercept/PubSubConsumerAdvice.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/intercept/PubSubConsumerAdvice.java
@@ -128,7 +128,7 @@ public class PubSubConsumerAdvice implements ExecutableMethodProcessor<Subscript
                         BoundExecutable executable = null;
                         try {
                             executable = binder.bind(method, binderRegistry, consumerState);
-                        } catch (Throwable ex) {
+                        } catch (Exception ex) {
                             handleException(new PubSubMessageReceiverException("Error binding message to the method", ex, bean, consumerState, autoAcknowledge));
                         }
                         executable.invoke(bean); // Discard result
@@ -146,7 +146,7 @@ public class PubSubConsumerAdvice implements ExecutableMethodProcessor<Subscript
                                 }
                             }
                         }
-                    } catch (Throwable e) {
+                    } catch (Exception e) {
                         handleException(new PubSubMessageReceiverException("Error handling message", e, bean, consumerState, autoAcknowledge));
                     }
                 };

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/intercept/PubSubConsumerAdvice.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/intercept/PubSubConsumerAdvice.java
@@ -61,7 +61,7 @@ import java.util.Optional;
  * and invoke methods annotated by @{@link io.micronaut.gcp.pubsub.annotation.Subscription}.
  * <p>
  * There can be only one subscriber for any given subscription (in order to avoid issues with message
- * Ack control). Having more than one method using the same subscription raises a {@link io.micronaut.gcp.pubsub.exception.PubSubListenerException}.
+ * acknowledgement control). Having more than one method using the same subscription raises a {@link io.micronaut.gcp.pubsub.exception.PubSubListenerException}.
  *
  * @author Vinicius Carvalho
  * @since 2.0.0
@@ -123,15 +123,16 @@ public class PubSubConsumerAdvice implements ExecutableMethodProcessor<Subscript
 
                     PubSubConsumerState consumerState = new PubSubConsumerState(message, ackReplyConsumer,
                             projectSubscriptionName, contentType);
+                    boolean autoAcknowledge = !hasAckArg;
                     try {
                         BoundExecutable executable = null;
                         try {
                             executable = binder.bind(method, binderRegistry, consumerState);
-                        } catch (Exception ex) {
-                            handleException(new PubSubMessageReceiverException("Error binding message to the method", ex, bean, consumerState));
+                        } catch (Throwable ex) {
+                            handleException(new PubSubMessageReceiverException("Error binding message to the method", ex, bean, consumerState, autoAcknowledge));
                         }
                         executable.invoke(bean); // Discard result
-                        if (!hasAckArg) { // if manual ack is not specified we auto ack message after method execution
+                        if (autoAcknowledge) { // if manual ack is not specified we auto ack message after method execution
                             pubSubAcknowledgement.ack();
                         } else {
                             Optional<Object> boundAck = Arrays
@@ -145,8 +146,8 @@ public class PubSubConsumerAdvice implements ExecutableMethodProcessor<Subscript
                                 }
                             }
                         }
-                    } catch (Exception e) {
-                        handleException(new PubSubMessageReceiverException("Error handling message", e, bean, consumerState));
+                    } catch (Throwable e) {
+                        handleException(new PubSubMessageReceiverException("Error handling message", e, bean, consumerState, autoAcknowledge));
                     }
                 };
                 try {
@@ -154,7 +155,6 @@ public class PubSubConsumerAdvice implements ExecutableMethodProcessor<Subscript
                 } catch (Exception e) {
                     throw new PubSubListenerException("Failed to create subscriber", e);
                 }
-
             }
         }
 

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/MockPubSubEngine.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/MockPubSubEngine.groovy
@@ -12,6 +12,11 @@ import java.util.stream.Collectors
 @Singleton
 class MockPubSubEngine implements AutoCloseable {
 
+
+    public final Map<PubsubMessage, String> acknowledgements = new ConcurrentHashMap<>();
+    public static final String ACK = "ack";
+    public static final String NACK = "nack";
+
     private final List<PublisherMessage> messages = new ArrayList<>(100);
     private final Map<String, MessageReceiver> receivers = new ConcurrentHashMap<>();
     private Worker worker = new Worker();
@@ -61,12 +66,12 @@ class MockPubSubEngine implements AutoCloseable {
                             entry.getValue().receiveMessage(availableMessage.message, new AckReplyConsumer() {
                                 @Override
                                 public void ack() {
-
+                                    acknowledgements.put(availableMessage.message, ACK)
                                 }
 
                                 @Override
                                 public void nack() {
-
+                                    acknowledgements.put(availableMessage.message, NACK)
                                 }
                             });
                             availableMessage.published = true;

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/bind/AcknowledgementSpec.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/bind/AcknowledgementSpec.groovy
@@ -1,0 +1,178 @@
+package io.micronaut.gcp.pubsub.bind
+
+import com.google.pubsub.v1.PubsubMessage
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.gcp.pubsub.AbstractConsumerSpec
+import io.micronaut.gcp.pubsub.MockPubSubEngine
+import io.micronaut.gcp.pubsub.annotation.PubSubClient
+import io.micronaut.gcp.pubsub.annotation.PubSubListener
+import io.micronaut.gcp.pubsub.annotation.Subscription
+import io.micronaut.gcp.pubsub.annotation.Topic
+import io.micronaut.gcp.pubsub.exception.DefaultPubSubMessageReceiverExceptionHandler
+import io.micronaut.gcp.pubsub.exception.PubSubMessageReceiverException
+import io.micronaut.gcp.pubsub.exception.PubSubMessageReceiverExceptionHandler
+import io.micronaut.gcp.pubsub.support.Person
+import io.micronaut.messaging.Acknowledgement
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.util.concurrent.PollingConditions
+
+@MicronautTest
+@Property(name = "spec.name", value = "AcknowledgementSpec")
+@Property(name = "gcp.projectId", value = "test-project")
+class AcknowledgementSpec extends AbstractConsumerSpec {
+
+    @Inject
+    DefaultPubSubMessageReceiverExceptionHandlerWrapper exceptionHandler
+
+    @Inject
+    AcknowledgementClient client
+
+    @Inject
+    AcknowledgementListener listener
+
+    @Inject
+    AcknowledgementListenerWithHandler listenerWithHandler
+
+    @Inject
+    MockPubSubEngine mockPubSubEngine
+
+    PollingConditions conditions = new PollingConditions(timeout: 3)
+
+    def setup() {
+        listener.msg = null
+        listener.manuallyProcessed = false
+        listenerWithHandler.ex = null;
+    }
+
+    void "automatically ack successfully processed message"() {
+        given:
+        byte[] payload = "success".getBytes()
+
+        when:
+        client.publishTopicAutoAck(payload)
+
+        then:
+        conditions.eventually {
+            listener.msg != null
+            def msg = listener.msg
+            mockPubSubEngine.acknowledgements.containsKey(msg)
+            mockPubSubEngine.acknowledgements.get(msg) == MockPubSubEngine.ACK
+        }
+    }
+
+    void "do not automatically ack a message when subscription method indicates manual acknowledgement"() {
+        given:
+        byte[] payload = "manual-success".getBytes()
+
+        when:
+        client.publishTopicManualAck(payload)
+
+        then:
+        conditions.eventually {
+            listener.manuallyProcessed
+            def msg = listener.msg
+            !mockPubSubEngine.acknowledgements.containsKey(msg)
+        }
+    }
+
+    void "automatically nack message with default exception handler"() {
+        given:
+        byte[] invalidPayload = "foo".getBytes()
+
+        when:
+        client.publishTopicNoHandler(invalidPayload)
+
+        then:
+        exceptionHandler instanceof DefaultPubSubMessageReceiverExceptionHandler
+        conditions.eventually {
+            exceptionHandler.ex != null
+            def msg = exceptionHandler.ex.state.pubsubMessage
+            mockPubSubEngine.acknowledgements.containsKey(msg)
+            mockPubSubEngine.acknowledgements.get(msg) == MockPubSubEngine.NACK
+        }
+    }
+
+    void "do not automatically nack message when subscription method indicates manual acknowledgement"() {
+        given:
+        byte[] invalidPayload = "baz".getBytes()
+
+        when:
+        client.publishTopicNoHandlerManuallyAcknowledged(invalidPayload)
+
+        then:
+        exceptionHandler instanceof DefaultPubSubMessageReceiverExceptionHandler
+        conditions.eventually {
+            exceptionHandler.ex != null
+            def msg = exceptionHandler.ex.state.pubsubMessage
+            !mockPubSubEngine.acknowledgements.containsKey(msg)
+        }
+    }
+
+    void "do not automatically nack message when a custom exception handler is provided"() {
+        given:
+        byte[] invalidPayload = "bar".getBytes()
+
+        when:
+        client.publishTopicHandler(invalidPayload)
+
+        then:
+        exceptionHandler instanceof DefaultPubSubMessageReceiverExceptionHandler
+        conditions.eventually {
+            listenerWithHandler.ex != null
+            def msg = listenerWithHandler.ex.state.pubsubMessage
+            !mockPubSubEngine.acknowledgements.containsKey(msg)
+        }
+    }
+}
+
+@PubSubClient
+@Requires(property = "spec.name", value = "AcknowledgementSpec")
+interface AcknowledgementClient {
+    @Topic("test-topic-with-message-auto-ack") void publishTopicAutoAck(byte[] data)
+    @Topic("test-topic-with-message-manually-acknowledged") void publishTopicManualAck(byte[] data)
+    @Topic("test-topic-no-handler") void publishTopicNoHandler(byte[] data)
+    @Topic("test-topic-no-handler-manually-acknowledged") void publishTopicNoHandlerManuallyAcknowledged(byte[] data)
+    @Topic("test-topic-handler") void publishTopicHandler(byte[] data)
+}
+
+@PubSubListener
+@Requires(property = "spec.name", value = "AcknowledgementSpec")
+class AcknowledgementListener {
+    PubsubMessage msg
+    boolean manuallyProcessed
+    @Subscription("test-topic-with-message-auto-ack") void onMessage(PubsubMessage msg) { this.msg = msg }
+    @Subscription("test-topic-with-message-manually-acknowledged") void onMessageManualAck(PubsubMessage msg, Acknowledgement acknowledgement) {
+        this.msg = msg
+        this.manuallyProcessed = true
+    }
+    @Subscription("test-topic-no-handler") void onPerson(Person person) {}
+    @Subscription("test-topic-no-handler-manually-acknowledged") void onPersonManualAck(Person person, Acknowledgement acknowledgement) {}
+}
+
+@PubSubListener
+@Requires(property = "spec.name", value = "AcknowledgementSpec")
+class AcknowledgementListenerWithHandler implements PubSubMessageReceiverExceptionHandler {
+    PubSubMessageReceiverException ex
+    @Subscription("test-topic-handler") void onMessage(Person person) {}
+    @Override void handle(PubSubMessageReceiverException exception) { ex = exception }
+}
+
+@Singleton
+@Primary
+@Replaces(DefaultPubSubMessageReceiverExceptionHandler)
+@Requires(property = "spec.name", value = "AcknowledgementSpec")
+class DefaultPubSubMessageReceiverExceptionHandlerWrapper extends DefaultPubSubMessageReceiverExceptionHandler {
+
+    public PubSubMessageReceiverException ex
+
+    @Override
+    void handle(PubSubMessageReceiverException exception) {
+        this.ex = exception
+        super.handle(ex);
+    }
+}

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/bind/AcknowledgementSpec.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/bind/AcknowledgementSpec.groovy
@@ -128,6 +128,16 @@ class AcknowledgementSpec extends AbstractConsumerSpec {
             !mockPubSubEngine.acknowledgements.containsKey(msg)
         }
     }
+
+    void "backwards-compatible behavior of auto acknowledge is retained for user tests"() {
+        when:
+        PubSubMessageReceiverException ex1 = new PubSubMessageReceiverException("test message 1", listener, null)
+        PubSubMessageReceiverException ex2 = new PubSubMessageReceiverException("test message 2", new IllegalStateException(), listener, null)
+
+        then:
+        !ex1.isAutoAcknowledge()
+        !ex2.isAutoAcknowledge()
+    }
 }
 
 @PubSubClient

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/bind/DefaultExceptionHandlerSpec.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/bind/DefaultExceptionHandlerSpec.groovy
@@ -74,6 +74,8 @@ class DefaultExceptionHandlerSpec extends AbstractConsumerSpec {
         }
     }
 
+
+
     @PubSubClient
     @Requires(property = "spec.name", value = "DefaultExceptionHandlerSpec")
     static interface SimpleClient {


### PR DESCRIPTION
The `DefaultPubSubMessageReceiverExceptionHandler` is modified to automatically nack failed messages if the 
targeted `@Subscription` method does not have an `Acknowledgement` parameter than indicates manual acknowledgement.

An `AcknowledgementSpec` test is added to cover all of the previously untested acknowledgement scenarios.

Closes #746 