### PR TITLE
improve javadoc for configuration reference documentation

### DIFF
--- a/gcp-secret-manager/src/main/java/io/micronaut/gcp/secretmanager/configuration/SecretManagerConfigurationProperties.java
+++ b/gcp-secret-manager/src/main/java/io/micronaut/gcp/secretmanager/configuration/SecretManagerConfigurationProperties.java
@@ -32,10 +32,11 @@ import java.util.Set;
 @BootstrapContextCompatible
 public class SecretManagerConfigurationProperties {
     public static final String PREFIX = GoogleCloudConfiguration.PREFIX + ".secret-manager";
+    private static final boolean DEFAULT_DEFAULT_CONFIG_ENABLED = true;
 
     private Set<String> customConfigs = new LinkedHashSet<>();
     private Set<String> keys = new HashSet<>();
-    private boolean defaultConfigEnabled = true;
+    private boolean defaultConfigEnabled = DEFAULT_DEFAULT_CONFIG_ENABLED;
 
     /**
      *
@@ -70,7 +71,7 @@ public class SecretManagerConfigurationProperties {
     }
 
     /**
-     *
+     * Whether to load the default config files. Default value: {@value #DEFAULT_DEFAULT_CONFIG_ENABLED}.
      * @return Whether to load the default config files.
      * @since 6.1.0
      */

--- a/gcp-secret-manager/src/main/java/io/micronaut/gcp/secretmanager/configuration/SecretManagerConfigurationProperties.java
+++ b/gcp-secret-manager/src/main/java/io/micronaut/gcp/secretmanager/configuration/SecretManagerConfigurationProperties.java
@@ -71,7 +71,7 @@ public class SecretManagerConfigurationProperties {
     }
 
     /**
-     * Whether to load the default config files. Default value: {@value #DEFAULT_DEFAULT_CONFIG_ENABLED}.
+     * Whether to load the default config files (`application`, `application_${env}`, `[APPLICATION_NAME], `[APPLICATION_NAME]_${env}`). Default value: {@value #DEFAULT_DEFAULT_CONFIG_ENABLED}.
      * @return Whether to load the default config files.
      * @since 6.1.0
      */


### PR DESCRIPTION
It is important to have good configuration reference documentation which you can generate locally by running `./gradlew docs`