### PR TITLE
Add 'nack-on-shutdown' configuration option

### DIFF
--- a/gcp-pubsub/build.gradle
+++ b/gcp-pubsub/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     testRuntimeOnly(mn.micronaut.discovery.core)
     testImplementation(mnRxjava2.micronaut.rxjava2)
     testImplementation libs.testcontainers.spock
+    testImplementation(mn.micronaut.http.server.netty)
 
     testAnnotationProcessor(mnSerde.micronaut.serde.processor)
     testImplementation(mnSerde.micronaut.serde.jackson)

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/configuration/PubSubConfigurationProperties.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/configuration/PubSubConfigurationProperties.java
@@ -38,9 +38,11 @@ public class PubSubConfigurationProperties {
 
     private String topicEndpoint = "";
 
+    private boolean nackOnShutdown = false;
+
     /**
-     *
-     * @return the name of the {@link java.util.concurrent.ScheduledExecutorService} to be used by all {@link com.google.cloud.pubsub.v1.Publisher} instances. Default: "scheduled"
+     * The name of the {@link java.util.concurrent.ScheduledExecutorService} to be used by all {@link com.google.cloud.pubsub.v1.Publisher} instances. Defaults to "scheduled".
+     * @return the name of the publishing executor
      *
      */
     public String getPublishingExecutor() {
@@ -56,9 +58,8 @@ public class PubSubConfigurationProperties {
     }
 
     /**
-     *
-     * @return the name of the {@link java.util.concurrent.ScheduledExecutorService} to be used by all {@link com.google.cloud.pubsub.v1.Subscriber} instances. Default: "scheduled"
-     * Defaults to "scheduled"
+     * The name of the {@link java.util.concurrent.ScheduledExecutorService} to be used by all {@link com.google.cloud.pubsub.v1.Subscriber} instances. Defaults to "scheduled".
+     * @return the name of the subscribing executor
      */
     public String getSubscribingExecutor() {
         return subscribingExecutor;
@@ -102,5 +103,23 @@ public class PubSubConfigurationProperties {
      */
     public void setTopicEndpoint(String topicEndpoint) {
         this.topicEndpoint = topicEndpoint;
+    }
+
+    /**
+     * Whether subscribers should stop processing pending in-memory messages and eagerly nack() during application shutdown. Defaults to false.
+     * @return nack on shutdown configuration
+     * @since 5.2.0
+     */
+    public boolean isNackOnShutdown() {
+        return this.nackOnShutdown;
+    }
+
+    /**
+     *
+     * @param nackOnShutdown whether subscribers should stop processing pending in-memory messages and eagerly nack() during application shutdown.
+     * @since 5.2.0
+     */
+    public void setNackOnShutdown(boolean nackOnShutdown) {
+        this.nackOnShutdown = nackOnShutdown;
     }
 }

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/integration/SubscriberShutdownSpec.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/integration/SubscriberShutdownSpec.groovy
@@ -1,0 +1,156 @@
+package io.micronaut.gcp.pubsub.integration
+
+import com.google.pubsub.v1.ProjectSubscriptionName
+import com.google.pubsub.v1.PubsubMessage
+import com.google.pubsub.v1.TopicName
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.gcp.pubsub.annotation.PubSubClient
+import io.micronaut.gcp.pubsub.annotation.PubSubListener
+import io.micronaut.gcp.pubsub.annotation.Subscription
+import io.micronaut.gcp.pubsub.annotation.Topic
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.annotation.PreDestroy
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class SubscriberShutdownSpec extends IntegrationTestSpec {
+
+    void "pending messages process to completion on shutdown by default"() {
+        given:
+        TopicName topicName = TopicName.of("test-project", "topic")
+        ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of("test-project", "topic-sub")
+        pubSubResourceAdmin.createTopic(topicName)
+        pubSubResourceAdmin.createSubscription(topicName, subscriptionName)
+        PollingConditions conditions = new PollingConditions(timeout: 10)
+        EmbeddedServer subscriberServer = ApplicationContext.run(EmbeddedServer, [
+                "server.name" : "ShutdownSubscriberServer",
+                "gcp.projectId" : "test-project"
+
+        ], "integration")
+
+        def ctx = ApplicationContext.run([
+                "spec.name" : "SubscriberShutdownSpec",
+                "gcp.projectId" : "test-project"
+        ], "integration")
+
+        when:
+        def listener = subscriberServer.getApplicationContext().getBean(MyPubSubListener.class)
+        def publisher = ctx.getBean(PubSubShutdownClient);
+
+        then:
+        listener != null
+        listener.count.get() == 0
+        publisher != null
+        subscriberServer.isRunning()
+
+        when:
+        for(int i = 0; i<100; i++) {
+            publisher.send("ping")
+        }
+
+        then:
+        conditions.eventually {
+            listener.count.intValue() > 1
+        }
+
+        when:
+        subscriberServer.stop()
+
+        then:
+        conditions.eventually {
+            !subscriberServer.isRunning()
+        }
+        listener.count.get() == 100
+    }
+
+    void "subscribers can eagerly nack messages on shutdown when configured"() {
+        given:
+        TopicName topicName = TopicName.of("test-project", "topic")
+        ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of("test-project", "topic-sub")
+        pubSubResourceAdmin.createTopic(topicName)
+        pubSubResourceAdmin.createSubscription(topicName, subscriptionName)
+        PollingConditions conditions = new PollingConditions(timeout: 10)
+        EmbeddedServer subscriberServer = ApplicationContext.run(EmbeddedServer, [
+                "server.name" : "ShutdownSubscriberServer",
+                "gcp.projectId" : "test-project",
+                "gcp.pubsub.nack-on-shutdown" : true
+
+        ], "integration")
+
+        def ctx = ApplicationContext.run([
+                "spec.name" : "SubscriberShutdownSpec",
+                "gcp.projectId" : "test-project"
+        ], "integration")
+
+        when:
+        def listener = subscriberServer.getApplicationContext().getBean(MyPubSubListener.class)
+        def publisher = ctx.getBean(PubSubShutdownClient);
+
+        then:
+        listener != null
+        listener.count.get() == 0
+        publisher != null
+        subscriberServer.isRunning()
+
+        when:
+        for(int i = 0; i<100; i++) {
+            publisher.send("ping")
+        }
+
+        then:
+        conditions.eventually {
+            listener.count.intValue() > 2
+        }
+
+        when:
+        subscriberServer.stop()
+
+        then:
+        conditions.eventually {
+            !subscriberServer.isRunning()
+        }
+        listener.count.get() < 100
+    }
+}
+
+@PubSubClient
+@Requires(property = "spec.name", value = "SubscriberShutdownSpec")
+interface PubSubShutdownClient {
+    @Topic(value ="topic")
+    void send(String msg)
+}
+
+@Requires(property = "server.name", value = "ShutdownSubscriberServer")
+@PubSubListener
+class MyPubSubListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MyPubSubListener.class);
+
+    AtomicInteger count = new AtomicInteger(0)
+
+    @Subscription(value = "topic-sub", configuration = "test")
+    public void onMessage(PubsubMessage message) {
+        var messageId = message.getMessageId();
+        LOG.debug("Received message with ID " + messageId + ". Invoking message processor.")
+
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            LOG.debug("Message processing interrupted", e)
+        }
+        LOG.debug("Message with ID " + messageId + " contents: " + message.getData() + ".")
+
+        int currentCount = count.incrementAndGet()
+        LOG.debug("Processor finished processing message with ID " + messageId + ".")
+        LOG.debug("Total Messages {}", currentCount)
+    }
+
+    @PreDestroy
+    void onShutdown() {
+        LOG.info("PreDestroy");
+    }
+}

--- a/gcp-pubsub/src/test/resources/logback.xml
+++ b/gcp-pubsub/src/test/resources/logback.xml
@@ -11,5 +11,5 @@
         <appender-ref ref="STDOUT" />
     </root>
 
-    <logger name="io.micronaut.context" level="trace" />
+    <logger name="io.micronaut.context" level="info" />
 </configuration>

--- a/src/main/docs/guide/pubsub/pubsubProperties.adoc
+++ b/src/main/docs/guide/pubsub/pubsubProperties.adoc
@@ -8,4 +8,6 @@ You can override it at PubSubConfigurationProperties to make a default value for
 
 Creating a custom executor is presented on the section <<executors, Configuring Thread pools >>.
 
+When the application is shutting down, `stopAsync()` is invoked on all of the running GCP library link:https://cloud.google.com/java/docs/reference/google-cloud-pubsub/latest/com.google.cloud.pubsub.v1.Subscriber[Subscriber] instances. The subscribers will attempt to fully process all pending in-memory messages before releasing the configured executor threads. By default, the framework will in turn continue to invoke the bound subscription methods on all <<pullConsumer, @PubSubListener>> beans until all messages have been processed. To discontinue processing of messages and enable faster shutdown, the `gcp.pubsub.nack-on-shutdown` property can be set to `true`, which will cause all pending unprocessed messages that have not yet reached a subscriber method to be eagerly nacked, which will cause PubSub to redeliver them according to each subscription's configuration.
+
 include::{includedir}configurationProperties/io.micronaut.gcp.pubsub.configuration.PubSubConfigurationProperties.adoc[]


### PR DESCRIPTION
A configuration property is added to allow the application shutdown behavior to be modified such that pending in-memory 
PubSub messages are eagerly nacked instead of processing to completion.

Tests are added to ensure the prior default behavior is retained and that the new configuration property works as 
intended.

Documentation is updated to explain the default shutdown behavior as well as the new configuration option.

Resolves #638
