### PR TITLE
Remove HeadersTest TCK exclusion

### DIFF
--- a/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-gcp-function-http/src/test/java/io/micronaut/http/server/tck/gcp/function/tests/GcpFunctionHttpServerTestSuite.java
@@ -11,8 +11,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.gcp.function.tests"
 })
 @ExcludeClassNamePatterns({
-    "io.micronaut.http.server.tck.tests.FilterProxyTest",
-    "io.micronaut.http.server.tck.tests.HeadersTest"
+    "io.micronaut.http.server.tck.tests.FilterProxyTest"
 })
 @SuiteDisplayName("HTTP Server TCK for for GCP Function HTTP")
 class GcpFunctionHttpServerTestSuite {


### PR DESCRIPTION
The exclusion for the TCK HeadersTest is removed as it now passes.