### PR TITLE
Fix warnings in asciidoc generation

### DIFF
--- a/test-suite-groovy/src/main/groovy/io/micronaut/gcp/pubsub/publisher/CustomReturnClient.groovy
+++ b/test-suite-groovy/src/main/groovy/io/micronaut/gcp/pubsub/publisher/CustomReturnClient.groovy
@@ -36,4 +36,4 @@ interface CustomReturnClient {
     Mono<String> sendReactive(Animal animal) //<3>
 
 }
-// tag::clazz[]
+// end::clazz[]

--- a/test-suite-groovy/src/main/groovy/io/micronaut/gcp/secretmanager/ClientExample.groovy
+++ b/test-suite-groovy/src/main/groovy/io/micronaut/gcp/secretmanager/ClientExample.groovy
@@ -38,4 +38,4 @@ import reactor.core.publisher.Mono
         Mono<VersionedSecret> fromOtherProject = client.getSecret("secretId", "latest", "another-project-id") //<3>
     }
 }
-//tag::clazz[]
+//end::clazz[]

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/bind/MessagePublishTime.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/bind/MessagePublishTime.kt
@@ -24,4 +24,4 @@ import io.micronaut.core.bind.annotation.Bindable
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Bindable // <1>
 annotation class MessagePublishTime
-//tag::clazz[]
+//end::clazz[]

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/bind/MessagePublishTimeAnnotationBinder.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/bind/MessagePublishTimeAnnotationBinder.kt
@@ -40,4 +40,4 @@ class MessagePublishTimeAnnotationBinder(private val conversionService: Conversi
 
 
 }
-// tag::clazz[]
+// end::clazz[]

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/publisher/CustomConfigurationClient.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/publisher/CustomConfigurationClient.kt
@@ -29,4 +29,4 @@ interface CustomConfigurationClient {
 	@Topic(value = "animals", configuration = "immediate")
 	fun send(animal: Animal)  // <2>
 }
-// tag::clazz[]
+// end::clazz[]

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/publisher/CustomReturnClient.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/publisher/CustomReturnClient.kt
@@ -34,5 +34,5 @@ interface CustomReturnClient {
 
 	@Topic("animals")
 	fun sendReactive(animal: Animal?): Mono<String> //<3>
-
 }
+// end::clazz[]

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/serdes/JavaMessageSerDes.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/serdes/JavaMessageSerDes.kt
@@ -52,4 +52,4 @@ class JavaMessageSerDes : PubSubMessageSerDes {
 		return baos.toByteArray()
 	}
 }
-// tag::clazz[]
+// end::clazz[]

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/subscriber/AcknowledgementSubscriber.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/subscriber/AcknowledgementSubscriber.kt
@@ -55,4 +55,4 @@ class AcknowledgementSubscriber(private val messageProcessor: MessageProcessor) 
             }
     }
 }
-// tag::clazz[]
+// end::clazz[]

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/subscriber/ErrorHandlingSubscriber.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/subscriber/ErrorHandlingSubscriber.kt
@@ -45,4 +45,4 @@ class ErrorHandlingSubscriber : PubSubMessageReceiverExceptionHandler { // <1>
 
 	}
 }
-// tag::clazz[]
+// end::clazz[]

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/subscriber/SimpleSubscriber.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/pubsub/subscriber/SimpleSubscriber.kt
@@ -30,12 +30,10 @@ class SimpleSubscriber {
 
 	@Subscription("animals") // <2>
 	fun onMessage(animal: Animal) {
-
 	}
 
 	@Subscription("projects/eu-project/subscriptions/animals") // <3>
 	fun onMessageEU(animal: Animal) {
-
 	}
-
 }
+// end::clazz[]

--- a/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/secretmanager/GoogleClientExample.kt
+++ b/test-suite-kotlin/src/main/kotlin/io/micronaut/gcp/secretmanager/GoogleClientExample.kt
@@ -34,3 +34,4 @@ class GoogleClientExample (private val client: SecretManagerServiceClient) { // 
 		val secret = response.payload.data.toStringUtf8()
 	}
 }
+//end::clazz[]

--- a/test-suite/src/main/java/io/micronaut/gcp/pubsub/publisher/CustomReturnClient.java
+++ b/test-suite/src/main/java/io/micronaut/gcp/pubsub/publisher/CustomReturnClient.java
@@ -35,4 +35,4 @@ public interface CustomReturnClient {
     Mono<String> sendReactive(Animal animal); //<3>
 
 }
-// tag::clazz[]
+// end::clazz[]

--- a/test-suite/src/main/java/io/micronaut/gcp/secretmanager/ClientExample.java
+++ b/test-suite/src/main/java/io/micronaut/gcp/secretmanager/ClientExample.java
@@ -38,4 +38,4 @@ public final class ClientExample {
         Mono<VersionedSecret> fromOtherProject = Mono.from(client.getSecret("secretId", "latest", "another-project-id")); //<3>
     }
 }
-//tag::clazz[]
+//end::clazz[]


### PR DESCRIPTION
We sometimes weren't closing tags, or were closing them incorrectly.

After this PR, all of the tag warnings generating the docs are gone