### PR TITLE
Break circular dependency when zipkin tracing is enabled

### DIFF
--- a/gcp-tracing/build.gradle.kts
+++ b/gcp-tracing/build.gradle.kts
@@ -13,4 +13,6 @@ dependencies {
     implementation(libs.brave.opentracing)
     testAnnotationProcessor(mn.micronaut.inject.java)
     testImplementation(mn.micronaut.inject.java)
+    testImplementation(mnSerde.micronaut.serde.jackson)
+    testImplementation(testFixtures(project(":micronaut-gcp-common")))
 }

--- a/gcp-tracing/src/test/groovy/io/micronaut/gcp/tracing/zipkin/StackdriverConfigurationSpec.groovy
+++ b/gcp-tracing/src/test/groovy/io/micronaut/gcp/tracing/zipkin/StackdriverConfigurationSpec.groovy
@@ -28,5 +28,8 @@ class StackdriverConfigurationSpec extends Specification {
         then:
         noExceptionThrown()
         sender
+        
+        cleanup:
+        ctx.close()
     }
 }

--- a/gcp-tracing/src/test/groovy/io/micronaut/gcp/tracing/zipkin/StackdriverConfigurationSpec.groovy
+++ b/gcp-tracing/src/test/groovy/io/micronaut/gcp/tracing/zipkin/StackdriverConfigurationSpec.groovy
@@ -1,0 +1,32 @@
+package io.micronaut.gcp.tracing.zipkin
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.gcp.credentials.GoogleCredentialsConfiguration
+import io.micronaut.gcp.credentials.fixture.ServiceAccountCredentialsTestHelper
+import spock.lang.Issue
+import spock.lang.Specification
+import zipkin2.reporter.Sender
+
+import java.security.PrivateKey
+
+class StackdriverConfigurationSpec extends Specification {
+
+    @Issue("https://github.com/micronaut-projects/micronaut-gcp/issues/1045")
+    void "application starts successfully with stackdriver and zipkin enabled"() {
+        given:
+        PrivateKey pk = ServiceAccountCredentialsTestHelper.generatePrivateKey()
+        File serviceAccountCredentials = ServiceAccountCredentialsTestHelper.writeServiceCredentialsToTempFile(pk)
+        ApplicationContext ctx = ApplicationContext.run([
+                "gcp.project-id" : "test-project",
+                (GoogleCredentialsConfiguration.PREFIX + ".location"): serviceAccountCredentials.getPath(),
+                "tracing.zipkin.enabled": true
+        ])
+
+        when:
+        Sender sender = ctx.getBean(Sender.class)
+
+        then:
+        noExceptionThrown()
+        sender
+    }
+}

--- a/gcp-tracing/src/test/resources/logback.xml
+++ b/gcp-tracing/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>false</withJansi>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/gcp-tracing/src/test/resources/logback.xml
+++ b/gcp-tracing/src/test/resources/logback.xml
@@ -1,7 +1,6 @@
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <withJansi>false</withJansi>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
Creating the default http client in the constructor of `DefaultOAuth2HttpTransportFactory` was causing a circular dependency when Zipkin tracing is enabled. There were no tests for `StackDriverSenderFactory` in the `gcp-tracing` module, thus the bug was undiscovered until users tried out the new release and reported the issue.

`DefaultOAuth2HttpTransportFactory` is updated to lazily create the default http client via a memoized `Supplier`, in the same manner as we do in the Micronaut Security JWKS client, and this breaks the dependency cycle.

A simple `StackdriverConfigurationSpec` is added to reproduce the issue and verify the fix.

This resolves #1045  