### PR TITLE
Map Logback log levels to allowed GCP Stackdriver severities

### DIFF
--- a/gcp-logging/src/main/java/io/micronaut/gcp/logging/StackdriverJsonLayout.java
+++ b/gcp-logging/src/main/java/io/micronaut/gcp/logging/StackdriverJsonLayout.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.gcp.logging;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.contrib.json.JsonFormatter;
@@ -35,6 +36,16 @@ import java.util.function.Supplier;
  * @since 3.2.0
  */
 public class StackdriverJsonLayout extends JsonLayout {
+    // GPC Logging has limited Severity values: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
+    private static final Map<Level, String> LOGBACK_TO_GCP_SEVERITY_MAP = Map.of(
+        Level.ALL, "DEBUG",
+        Level.TRACE, "DEBUG",
+        Level.DEBUG, "DEBUG",
+        Level.INFO, "INFO",
+        Level.WARN, "WARNING",
+        Level.ERROR, "ERROR"
+    );
+    private static final String DEFAULT_LOG_SEVERITY = "DEBUG";
 
     private static final Set<String> FILTERED_MDC_FIELDS = new HashSet<>(Arrays.asList(
             StackdriverTraceConstants.MDC_FIELD_TRACE_ID,
@@ -102,7 +113,7 @@ public class StackdriverJsonLayout extends JsonLayout {
         }
 
         add(StackdriverTraceConstants.SEVERITY_ATTRIBUTE, this.includeLevel,
-                String.valueOf(event.getLevel()), map);
+                LOGBACK_TO_GCP_SEVERITY_MAP.getOrDefault(event.getLevel(), DEFAULT_LOG_SEVERITY), map);
         add(JsonLayout.THREAD_ATTR_NAME, this.includeThreadName, event.getThreadName(), map);
         add(JsonLayout.LOGGER_ATTR_NAME, this.includeLoggerName, event.getLoggerName(), map);
 

--- a/gcp-logging/src/test/groovy/io/micronaut/gcp/logging/StackdriverJsonLayoutSpec.groovy
+++ b/gcp-logging/src/test/groovy/io/micronaut/gcp/logging/StackdriverJsonLayoutSpec.groovy
@@ -1,0 +1,41 @@
+package io.micronaut.gcp.logging
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.spi.LoggingEvent
+import spock.lang.Specification
+
+import java.util.concurrent.TimeUnit
+
+class StackdriverJsonLayoutSpec extends Specification {
+    StackdriverJsonLayout stackdriverJsonLayout = new StackdriverJsonLayout()
+    LoggerContext loggerContext = new LoggerContext()
+
+    void "should properly map log level to GCP severity"() {
+        given:
+        def event = new LoggingEvent(
+                this.class.canonicalName, loggerContext.getLogger(this.class), logLevel, 'the message', new IllegalArgumentException('exception message'), new Object[]{}
+        )
+        event.setMDCPropertyMap([:])
+
+        when:
+        def result = stackdriverJsonLayout.toJsonMap(event)
+
+        then:
+        result['severity'] == expectedSeverity
+        result['message'] == 'the message\njava.lang.IllegalArgumentException: exception message\n'
+        result['thread'] == 'main'
+        result['logger'] == this.class.canonicalName
+        result['timestampSeconds'] == TimeUnit.MILLISECONDS.toSeconds(event.timeStamp)
+        result['timestampNanos'] == TimeUnit.MILLISECONDS.toNanos(event.getTimeStamp() % 1_000)
+
+        where:
+        logLevel    || expectedSeverity
+        Level.ALL   || 'DEBUG'
+        Level.TRACE || 'DEBUG'
+        Level.DEBUG || 'DEBUG'
+        Level.INFO  || 'INFO'
+        Level.WARN  || 'WARNING'
+        Level.ERROR || 'ERROR'
+    }
+}


### PR DESCRIPTION
Map the native Logback log levels to the allowed GCP Stackdriver logging severities. Also provides a sensible default if the log levels ever has an unexpected value in it.

Added an initial spec as well.

Fixes: #1130
