### PR TITLE
Map Logback log levels to allowed GCP Stackdriver severities

### DIFF
--- a/gcp-logging/src/test/groovy/io/micronaut/gcp/logging/StackdriverJsonLayoutSpec.groovy
+++ b/gcp-logging/src/test/groovy/io/micronaut/gcp/logging/StackdriverJsonLayoutSpec.groovy
@@ -1,0 +1,41 @@
+package io.micronaut.gcp.logging
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.spi.LoggingEvent
+import spock.lang.Specification
+
+import java.util.concurrent.TimeUnit
+
+class StackdriverJsonLayoutSpec extends Specification {
+    StackdriverJsonLayout stackdriverJsonLayout = new StackdriverJsonLayout()
+    LoggerContext loggerContext = new LoggerContext()
+
+    void "should properly map log level to GCP severity"() {
+        given:
+        def event = new LoggingEvent(
+                this.class.canonicalName, loggerContext.getLogger(this.class), logLevel, 'the message', new IllegalArgumentException('exception message'), new Object[]{}
+        )
+        event.setMDCPropertyMap([:])
+
+        when:
+        def result = stackdriverJsonLayout.toJsonMap(event)
+
+        then:
+        result['severity'] == expectedSeverity
+        result['message'] == 'the message\njava.lang.IllegalArgumentException: exception message\n'
+        result['thread'] == 'main'
+        result['logger'] == this.class.canonicalName
+        result['timestampSeconds'] == TimeUnit.MILLISECONDS.toSeconds(event.timeStamp)
+        result['timestampNanos'] == TimeUnit.MILLISECONDS.toNanos(event.getTimeStamp() % 1_000)
+
+        where:
+        logLevel    || expectedSeverity
+        Level.ALL   || 'DEBUG'
+        Level.TRACE || 'DEBUG'
+        Level.DEBUG || 'DEBUG'
+        Level.INFO  || 'INFO'
+        Level.WARN  || 'WARNING'
+        Level.ERROR || 'ERROR'
+    }
+}


### PR DESCRIPTION
Map the native Logback log levels to the allowed GCP Stackdriver logging severities. Also provides a sensible default if the log levels ever has an unexpected value in it.

Added an initial spec as well.

Fixes: https://github.com/micronaut-projects/micronaut-gcp/issues/1130 