### PR TITLE
disable DefaultOauth2HttpTransportFactory by default

### DIFF
--- a/gcp-common/src/main/java/io/micronaut/gcp/credentials/DefaultOAuth2HttpTransportFactory.java
+++ b/gcp-common/src/main/java/io/micronaut/gcp/credentials/DefaultOAuth2HttpTransportFactory.java
@@ -56,7 +56,7 @@ import java.util.function.Supplier;
  */
 @Singleton
 @Requires(classes = HttpClient.class)
-@Requires(property = GoogleCredentialsConfiguration.PREFIX + ".use-http-client", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+@Requires(property = GoogleCredentialsConfiguration.PREFIX + ".use-http-client", value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
 public class DefaultOAuth2HttpTransportFactory implements HttpTransportFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultOAuth2HttpTransportFactory.class);

--- a/gcp-common/src/test/groovy/io/micronaut/gcp/credentials/DefaultOAuth2HttpTransportFactoryDisabledSpec.groovy
+++ b/gcp-common/src/test/groovy/io/micronaut/gcp/credentials/DefaultOAuth2HttpTransportFactoryDisabledSpec.groovy
@@ -8,7 +8,6 @@ import jakarta.inject.Inject
 import spock.lang.Specification
 
 @MicronautTest
-@Property(name = "gcp.credentials.use-http-client", value = StringUtils.FALSE)
 class DefaultOAuth2HttpTransportFactoryDisabledSpec extends Specification {
 
     @Inject

--- a/gcp-common/src/test/groovy/io/micronaut/gcp/credentials/GoogleCredentialsFactorySpec.groovy
+++ b/gcp-common/src/test/groovy/io/micronaut/gcp/credentials/GoogleCredentialsFactorySpec.groovy
@@ -13,6 +13,7 @@ import io.micronaut.context.exceptions.BeanInstantiationException
 import io.micronaut.context.exceptions.ConfigurationException
 import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.core.reflect.ReflectionUtils
+import io.micronaut.core.util.StringUtils
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.MediaType
@@ -275,6 +276,7 @@ class GoogleCredentialsFactorySpec extends Specification {
                 "micronaut.server.port" : 8080
         ])
         def ctx = ApplicationContext.run([
+                "gcp.credentials.use-http-client" : StringUtils.TRUE,
                 (GoogleCredentialsConfiguration.PREFIX + ".location"): serviceAccountCredentials.getPath()
         ])
         GoogleCredentials gc = ctx.getBean(GoogleCredentials)
@@ -302,6 +304,7 @@ class GoogleCredentialsFactorySpec extends Specification {
                 "micronaut.server.port" : 8080
         ])
         def ctx = ApplicationContext.run([
+                "gcp.credentials.use-http-client" : StringUtils.TRUE,
                 (GoogleCredentialsConfiguration.PREFIX + ".encoded-key"): encodedServiceAccountCredentials
         ])
         GoogleCredentials gc = ctx.getBean(GoogleCredentials)


### PR DESCRIPTION
when using `DefaultOauthHttpTransportFactory` and a service account in GCP you get errors such as:

```
"message": "Invalid JSON payload received. Unexpected token.\nclient_id=7430761518\n
```

This PR don’t load `DefaultOauthHttpTransportFactory` by default.