### PR TITLE
Upgrade com.google.cloud.opentelemetry:exporter-auto dependency to 0.36.0-alpha

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,8 @@ sonatype-scan = "3.1.1"
 # Micronaut
 micronaut-gradle-plugin = "4.5.3"
 
+opentelemetry-exporter-auto = '0.36.0-alpha'
+
 [libraries]
 # Core
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
@@ -85,6 +87,8 @@ zipkin-sender-stackdriver = { module = "io.zipkin.gcp:zipkin-sender-stackdriver"
 awaitility = { module = 'org.awaitility:awaitility', version.ref = 'awaitility' }
 system-stubs-core = { module = "uk.org.webcompere:system-stubs-core", version.ref = "system-stubs-core" }
 sonatype-scan = { module = "org.sonatype.gradle.plugins:scan-gradle-plugin", version.ref = "sonatype-scan" }
+
+com-google-cloud-opentelemetry-exporter-auto = { module = 'com.google.cloud.opentelemetry:exporter-auto', version.ref = 'opentelemetry-exporter-auto'}
 
 # Plugins
 gradle-micronaut = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref = "micronaut-gradle-plugin" }


### PR DESCRIPTION
When running a Micronaut application that includes the `com.google.cloud.opentelemetry:exporter-auto:0.33.0-alpha` as a transitive dependency, a runtime exception is thrown:


 ```
_                                  _   
|  \/  (_) ___ _ __ ___  _ __   __ _ _   _| |_ 
| |\/| | |/ __| '__/ _ \| '_ \ / _` | | | | __|
| |  | | | (__| | | (_) | | | | (_| | |_| | |_ 
|_|  |_|_|\___|_|  \___/|_| |_|\__,_|\__,_|\__|
23:58:28.644 [main] INFO  io.micronaut.runtime.Micronaut - Startup completed in 575ms. Server Running: http://localhost:8080/
Exception in thread "BatchSpanProcessor_WorkerThread-1" java.lang.NoClassDefFoundError: io/opentelemetry/semconv/ResourceAttributes
	at com.google.cloud.opentelemetry.trace.TraceVersions.readSdkVersion(TraceVersions.java:32)
	at com.google.cloud.opentelemetry.trace.TraceVersions.<clinit>(TraceVersions.java:27)
	at com.google.cloud.opentelemetry.trace.InternalTraceExporter.<clinit>(InternalTraceExporter.java:56)
	at com.google.cloud.opentelemetry.trace.TraceExporter.lambda$new$0(TraceExporter.java:41)
	at com.google.common.base.Suppliers$NonSerializableMemoizingSupplier.get(Suppliers.java:198)
	at com.google.cloud.opentelemetry.trace.TraceExporter.export(TraceExporter.java:93)
	at io.opentelemetry.sdk.trace.export.BatchSpanProcessor$Worker.exportCurrentBatch(BatchSpanProcessor.java:344)
	at io.opentelemetry.sdk.trace.export.BatchSpanProcessor$Worker.run(BatchSpanProcessor.java:258)
	at java.base/java.lang.Thread.run(Thread.java:842)
Caused by: java.lang.ClassNotFoundException: io.opentelemetry.semconv.ResourceAttributes
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	... 9 more
```

	
This error occurs during the export of spans, typically triggered by HTTP requests where attributes are set on spans ( **Span.current().setAttribute("inventory.store-name", store)**). The underlying issue is that the ResourceAttributes class has been removed or moved in newer versions of the OpenTelemetry semantic conventions, and the 0.33.0-alpha version of the `com.google.cloud.opentelemetry:exporter-auto` is not compatible with these changes.

Upgraded `com.google.cloud.opentelemetry:exporter-auto` from 0.33.0-alpha to 0.36.0-alpha, resolves the compatibility issue with the OpenTelemetry API.

After the upgrade, the application runs successfully and exports trace data without errors, even when span attributes are set during HTTP request handling.
	
	