### PR TITLE
Upgrade Stackdriver sender to v2

### DIFF
--- a/gcp-tracing/build.gradle.kts
+++ b/gcp-tracing/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     api(mnTracing.micronaut.tracing.brave.http)
     implementation(libs.google.auth.library.credentials)
     implementation(libs.zipkin.sender.stackdriver)
+    implementation(libs.zipkin.stackdriver.encoder)
     implementation(libs.brave.propagation.stackdriver)
     implementation(platform(mnGrpc.boms.grpc))
     implementation(libs.grpc.auth)

--- a/gcp-tracing/src/main/java/io/micronaut/gcp/tracing/zipkin/StackdriverSenderFactory.java
+++ b/gcp-tracing/src/main/java/io/micronaut/gcp/tracing/zipkin/StackdriverSenderFactory.java
@@ -37,15 +37,20 @@ import io.micronaut.tracing.brave.BraveTracerConfiguration;
 import zipkin2.Span;
 import zipkin2.reporter.AsyncReporter;
 import zipkin2.reporter.BytesEncoder;
+import zipkin2.reporter.Call;
+import zipkin2.reporter.Callback;
+import zipkin2.reporter.Encoding;
 import zipkin2.reporter.Sender;
-import zipkin2.reporter.stackdriver.StackdriverEncoder;
 import zipkin2.reporter.stackdriver.StackdriverSender;
+import zipkin2.reporter.stackdriver.zipkin.StackdriverEncoder;
 
 import org.jspecify.annotations.NonNull;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
+import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Configures the {@link StackdriverSender} for Micronaut if present on the classpath.
@@ -105,11 +110,12 @@ public class StackdriverSenderFactory {
 
         GoogleCredentials traceCredentials = credentials.createScoped(Arrays.asList(TRACE_SCOPE.toString()));
 
-        return StackdriverSender.newBuilder(channel)
+        StackdriverSender sender = StackdriverSender.newBuilder(channel)
                 .projectId(cloudConfiguration.getProjectId())
                 .callOptions(CallOptions.DEFAULT
                         .withCallCredentials(MoreCallCredentials.from(traceCredentials)))
                 .build();
+        return new StackdriverSenderAdapter(sender);
     }
 
     /**
@@ -136,7 +142,7 @@ public class StackdriverSenderFactory {
      * @return The bean.
      */
     @Singleton
-    @Requires(beans = StackdriverSender.class)
+    @Requires(beans = Sender.class)
     protected Propagation.Factory stackdriverPropagation() {
         return StackdriverTracePropagation.newFactory(B3Propagation.FACTORY);
     }
@@ -153,5 +159,91 @@ public class StackdriverSenderFactory {
     public AsyncReporter<Span> stackdriverReporter(@NonNull AsyncReporterConfiguration configuration) {
         return configuration.getBuilder()
                 .build((BytesEncoder<Span>) StackdriverEncoder.V2);
+    }
+
+    private static final class StackdriverSenderAdapter extends Sender {
+        private final StackdriverSender sender;
+
+        private StackdriverSenderAdapter(StackdriverSender sender) {
+            this.sender = sender;
+        }
+
+        @Override
+        public Encoding encoding() {
+            return sender.encoding();
+        }
+
+        @Override
+        public int messageMaxBytes() {
+            return sender.messageMaxBytes();
+        }
+
+        @Override
+        public int messageSizeInBytes(List<byte[]> encodedSpans) {
+            return sender.messageSizeInBytes(encodedSpans);
+        }
+
+        @Override
+        public int messageSizeInBytes(int encodedSizeInBytes) {
+            return sender.messageSizeInBytes(encodedSizeInBytes);
+        }
+
+        @Override
+        public Call<Void> sendSpans(List<byte[]> encodedSpans) {
+            return new StackdriverSenderCall(sender, encodedSpans);
+        }
+
+        @Override
+        public void send(List<byte[]> encodedSpans) throws IOException {
+            sender.send(encodedSpans);
+        }
+
+        @Override
+        public void close() {
+            sender.close();
+        }
+    }
+
+    private static final class StackdriverSenderCall extends Call<Void> {
+        private final StackdriverSender sender;
+        private final List<byte[]> encodedSpans;
+        private boolean canceled;
+
+        private StackdriverSenderCall(StackdriverSender sender, List<byte[]> encodedSpans) {
+            this.sender = sender;
+            this.encodedSpans = encodedSpans;
+        }
+
+        @Override
+        public Void execute() throws IOException {
+            sender.send(encodedSpans);
+            return null;
+        }
+
+        @Override
+        public void enqueue(Callback<Void> callback) {
+            try {
+                execute();
+                callback.onSuccess(null);
+            } catch (Throwable e) {
+                propagateIfFatal(e);
+                callback.onError(e);
+            }
+        }
+
+        @Override
+        public void cancel() {
+            canceled = true;
+        }
+
+        @Override
+        public boolean isCanceled() {
+            return canceled;
+        }
+
+        @Override
+        public Call<Void> clone() {
+            return new StackdriverSenderCall(sender, encodedSpans);
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ brave-propagation-stackdriver = "2.3.1"
 cloudevents-api = "2.5.0"
 
 logback-json-classic = "0.1.5"
-zipkin-sender-stackdriver = "1.1.1"
+zipkin-sender-stackdriver = "2.3.1"
 system-stubs-core = "2.1.8"
 
 awaitility = '4.3.0'
@@ -73,6 +73,7 @@ grpc-auth = { module = "io.grpc:grpc-auth" }
 grpc-netty-shaded = { module = "io.grpc:grpc-netty-shaded" }
 logback-json-classic = { module = "ch.qos.logback.contrib:logback-json-classic", version.ref = "logback-json-classic" }
 zipkin-sender-stackdriver = { module = "io.zipkin.gcp:zipkin-sender-stackdriver", version.ref = "zipkin-sender-stackdriver" }
+zipkin-stackdriver-encoder = { module = "io.zipkin.gcp:zipkin-encoder-stackdriver", version.ref = "zipkin-sender-stackdriver" }
 awaitility = { module = 'org.awaitility:awaitility', version.ref = 'awaitility' }
 system-stubs-core = { module = "uk.org.webcompere:system-stubs-core", version.ref = "system-stubs-core" }
 testcontainers = { module = "org.testcontainers:testcontainers" }


### PR DESCRIPTION
## Summary
- stack this change on top of #1470 instead of modifying that PR
- upgrade `io.zipkin.gcp:zipkin-sender-stackdriver` from 1.1.1 to 2.3.1
- add the `zipkin-encoder-stackdriver` artifact required by zipkin-gcp v2
- adapt Stackdriver tracing wiring for the v2 sender API while preserving Micronaut's `Sender` bean contract

## Validation
- `./gradlew :micronaut-gcp-tracing:check :test-suite:compileTestJava --no-daemon --stacktrace`

Depends on #1470.
