### PR TITLE
Fix Pub/Sub publishing during graceful shutdown

### DIFF
--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/bind/DefaultSubscriberFactory.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/bind/DefaultSubscriberFactory.java
@@ -23,22 +23,28 @@ import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.cloud.pubsub.v1.SubscriberInterface;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import io.micronaut.context.BeanContext;
+import io.micronaut.core.order.Ordered;
 import io.micronaut.gcp.Modules;
 import io.micronaut.gcp.pubsub.configuration.SubscriberConfigurationProperties;
 import io.micronaut.gcp.pubsub.exception.PubSubListenerException;
 import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.runtime.graceful.GracefulShutdownCapable;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PreDestroy;
+import jakarta.annotation.PreDestroy;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Default implementation of {@link SubscriberFactory}.
@@ -46,13 +52,14 @@ import java.util.concurrent.ScheduledExecutorService;
  * @since 2.0.0
  */
 @Singleton
-public class DefaultSubscriberFactory implements SubscriberFactory, AutoCloseable {
+public class DefaultSubscriberFactory implements SubscriberFactory, AutoCloseable, GracefulShutdownCapable, Ordered {
 
     private final ConcurrentHashMap<ProjectSubscriptionName, Subscriber> subscribers = new ConcurrentHashMap<>();
     private final TransportChannelProvider transportChannelProvider;
     private final CredentialsProvider credentialsProvider;
     private final BeanContext beanContext;
     private final Logger logger = LoggerFactory.getLogger(DefaultSubscriberFactory.class);
+    private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
     public DefaultSubscriberFactory(@Named(Modules.PUBSUB) TransportChannelProvider transportChannelProvider,
                                     @Named(Modules.PUBSUB) CredentialsProvider credentialsProvider,
@@ -64,6 +71,9 @@ public class DefaultSubscriberFactory implements SubscriberFactory, AutoCloseabl
 
     @Override
     public Subscriber createSubscriber(SubscriberFactoryConfig config) {
+        if (shutdown.get()) {
+            throw new PubSubListenerException("Cannot create subscriber after shutdown has been initiated");
+        }
         Subscriber subscriber = subscribers.compute(config.getSubscriptionName(), (k, v) -> {
             if (v == null) {
                 Subscriber.Builder builder = Subscriber.newBuilder(config.getSubscriptionName(), config.getReceiver())
@@ -96,6 +106,9 @@ public class DefaultSubscriberFactory implements SubscriberFactory, AutoCloseabl
     @PreDestroy
     @Override
     public void close() throws Exception {
+        if (!shutdown.compareAndSet(false, true)) {
+            return;
+        }
         while (!subscribers.entrySet().isEmpty()) {
             Iterator<Map.Entry<ProjectSubscriptionName, Subscriber>> it = subscribers.entrySet().iterator();
             while (it.hasNext()) {
@@ -118,6 +131,26 @@ public class DefaultSubscriberFactory implements SubscriberFactory, AutoCloseabl
                 }
             }
         }
+    }
+
+    @Override
+    public CompletionStage<?> shutdownGracefully() {
+        try {
+            close();
+        } catch (Exception e) {
+            logger.error("Failed stopping subscribers during graceful shutdown", e);
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public OptionalLong reportActiveTasks() {
+        return OptionalLong.of(subscribers.values().stream().filter(SubscriberInterface::isRunning).count());
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE + 100;
     }
 
     final boolean isRunning(ProjectSubscriptionName subscriptionName) {

--- a/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/intercept/AbstractPubSubConsumerMethodProcessor.java
+++ b/gcp-pubsub/src/main/java/io/micronaut/gcp/pubsub/intercept/AbstractPubSubConsumerMethodProcessor.java
@@ -27,6 +27,7 @@ import io.micronaut.core.bind.BoundExecutable;
 import io.micronaut.core.bind.DefaultExecutableBinder;
 import io.micronaut.core.bind.exceptions.UnsatisfiedArgumentException;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.order.Ordered;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.gcp.GoogleCloudConfiguration;
 import io.micronaut.gcp.pubsub.annotation.PubSubListener;
@@ -42,6 +43,7 @@ import io.micronaut.inject.ExecutableMethod;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.messaging.Acknowledgement;
 import io.micronaut.messaging.exceptions.MessageListenerException;
+import io.micronaut.runtime.graceful.GracefulShutdownCapable;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Qualifier;
 import org.reactivestreams.Publisher;
@@ -53,6 +55,8 @@ import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -69,7 +73,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @since 5.4.0
  */
 @Internal
-abstract class AbstractPubSubConsumerMethodProcessor<A extends Annotation> implements ExecutableMethodProcessor<A> {
+abstract class AbstractPubSubConsumerMethodProcessor<A extends Annotation> implements ExecutableMethodProcessor<A>, GracefulShutdownCapable, Ordered {
 
     protected final BeanContext beanContext;
     protected final ConversionService conversionService;
@@ -161,6 +165,17 @@ abstract class AbstractPubSubConsumerMethodProcessor<A extends Annotation> imple
     @PreDestroy
     public final void shutDown() {
         shutDownMode.set(true);
+    }
+
+    @Override
+    public CompletionStage<?> shutdownGracefully() {
+        shutDown();
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
     }
 
     /**

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/bind/DefaultSubscriberFactorySpec.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/bind/DefaultSubscriberFactorySpec.groovy
@@ -1,0 +1,49 @@
+package io.micronaut.gcp.pubsub.bind
+
+import com.google.api.gax.core.CredentialsProvider
+import com.google.api.gax.rpc.TransportChannelProvider
+import com.google.cloud.pubsub.v1.Subscriber
+import com.google.pubsub.v1.ProjectSubscriptionName
+import io.micronaut.context.BeanContext
+import io.micronaut.core.order.Ordered
+import io.micronaut.runtime.graceful.GracefulShutdownCapable
+import spock.lang.Specification
+
+class DefaultSubscriberFactorySpec extends Specification {
+
+    void "subscriber factory participates in graceful shutdown before executors"() {
+        given:
+        def factory = new DefaultSubscriberFactory(
+                Mock(TransportChannelProvider),
+                Mock(CredentialsProvider),
+                Mock(BeanContext)
+        )
+
+        expect:
+        factory instanceof GracefulShutdownCapable
+        factory.order == Ordered.HIGHEST_PRECEDENCE + 100
+    }
+
+    void "graceful shutdown stops subscribers once"() {
+        given:
+        def factory = new DefaultSubscriberFactory(
+                Mock(TransportChannelProvider),
+                Mock(CredentialsProvider),
+                Mock(BeanContext)
+        )
+        def subscriptionName = ProjectSubscriptionName.of("test-project", "test-subscription")
+        def subscriber = Mock(Subscriber)
+        factory.@subscribers.put(subscriptionName, subscriber)
+
+        when:
+        def shutdown = factory.shutdownGracefully()
+        factory.close()
+
+        then:
+        shutdown.toCompletableFuture().done
+        1 * subscriber.isRunning() >> true
+        1 * subscriber.stopAsync() >> subscriber
+        1 * subscriber.awaitTerminated() >> subscriber
+        0 * subscriber._
+    }
+}

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/integration/SubscriberShutdownSpec.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/integration/SubscriberShutdownSpec.groovy
@@ -38,7 +38,8 @@ class SubscriberShutdownSpec extends IntegrationTestSpec {
         PollingConditions conditions = new PollingConditions(timeout: 10)
         EmbeddedServer subscriberServer = ApplicationContext.run(EmbeddedServer, [
                 "server.name" : "ShutdownSubscriberServer",
-                "gcp.projectId" : "test-project"
+                "gcp.projectId" : "test-project",
+                "micronaut.lifecycle.graceful-shutdown.enabled" : true
 
         ], "integration")
 
@@ -90,6 +91,7 @@ class SubscriberShutdownSpec extends IntegrationTestSpec {
         EmbeddedServer subscriberServer = ApplicationContext.run(EmbeddedServer, [
                 "server.name" : "ShutdownSubscriberServer",
                 "gcp.projectId" : "test-project",
+                "micronaut.lifecycle.graceful-shutdown.enabled" : true,
                 "micronaut.executors.scheduled.core-pool-size" : 5,
                 "gcp.pubsub.nack-on-shutdown" : true
 

--- a/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/intercept/AbstractPubSubConsumerMethodProcessorSpec.groovy
+++ b/gcp-pubsub/src/test/groovy/io/micronaut/gcp/pubsub/intercept/AbstractPubSubConsumerMethodProcessorSpec.groovy
@@ -1,0 +1,55 @@
+package io.micronaut.gcp.pubsub.intercept
+
+import com.google.cloud.pubsub.v1.MessageReceiver
+import com.google.pubsub.v1.ProjectSubscriptionName
+import io.micronaut.context.BeanContext
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.order.Ordered
+import io.micronaut.gcp.GoogleCloudConfiguration
+import io.micronaut.gcp.pubsub.annotation.Subscription
+import io.micronaut.gcp.pubsub.bind.PubSubBinderRegistry
+import io.micronaut.gcp.pubsub.exception.PubSubMessageReceiverExceptionHandler
+import io.micronaut.runtime.graceful.GracefulShutdownCapable
+import spock.lang.Specification
+
+class AbstractPubSubConsumerMethodProcessorSpec extends Specification {
+
+    void "consumer processor enters shutdown mode during graceful shutdown"() {
+        given:
+        def processor = new TestConsumerMethodProcessor(
+                Mock(BeanContext),
+                Mock(ConversionService),
+                Mock(GoogleCloudConfiguration),
+                Mock(PubSubBinderRegistry),
+                Mock(PubSubMessageReceiverExceptionHandler)
+        )
+
+        when:
+        def shutdown = processor.shutdownGracefully()
+
+        then:
+        processor instanceof GracefulShutdownCapable
+        processor.order == Ordered.HIGHEST_PRECEDENCE
+        processor.shutdownInitiated()
+        shutdown.toCompletableFuture().done
+    }
+
+    private static final class TestConsumerMethodProcessor extends AbstractPubSubConsumerMethodProcessor<Subscription> {
+
+        TestConsumerMethodProcessor(BeanContext beanContext,
+                                    ConversionService conversionService,
+                                    GoogleCloudConfiguration googleCloudConfiguration,
+                                    PubSubBinderRegistry binderRegistry,
+                                    PubSubMessageReceiverExceptionHandler exceptionHandler) {
+            super(Subscription, beanContext, conversionService, googleCloudConfiguration, binderRegistry, exceptionHandler)
+        }
+
+        @Override
+        protected void addSubscriber(ProjectSubscriptionName projectSubscriptionName, MessageReceiver receiver, String configuration) {
+        }
+
+        boolean shutdownInitiated() {
+            isShutDownInitiated()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make Pub/Sub pull consumer shutdown participate in Micronaut core graceful shutdown
- stop subscribers during the graceful shutdown phase before scheduled executors are shut down
- keep `@PreDestroy` shutdown as the fallback path and add focused coverage for ordering/idempotence

## Tests
- `./gradlew :micronaut-gcp-pubsub:test --tests io.micronaut.gcp.pubsub.bind.DefaultSubscriberFactorySpec --tests io.micronaut.gcp.pubsub.intercept.AbstractPubSubConsumerMethodProcessorSpec`
- `./gradlew :micronaut-gcp-pubsub:spotlessCheck`

Note: `SubscriberShutdownSpec` was also attempted locally, but the Pub/Sub emulator was unreachable at `localhost:<mapped-port>` with `Connection refused` before shutdown behavior was exercised.

Resolves https://github.com/micronaut-projects/micronaut-gcp/issues/1414
