### PR TITLE
Update CloudEvents SDK to v4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ managed-gax = "2.79.0"
 brave-opentracing = "1.0.1"
 brave-propagation-stackdriver = "2.3.1"
 
-cloudevents-api = "2.5.0"
+cloudevents-api = "4.0.2"
 
 logback-json-classic = "0.1.5"
 netty = "4.2.13.Final"


### PR DESCRIPTION
## Summary
- upgrade `io.cloudevents:cloudevents-api` and `io.cloudevents:cloudevents-core` from `2.5.0` to `4.0.2`
- carry Renovate PR #1466 as valid for the unreleased `6.0.x` major line
- note that Renovate PR #1458 is already present on `6.0.x` through merged PR #1470

## Validation
- `./gradlew :micronaut-gcp-function-cloudevents:check :micronaut-gcp-serde-cloudevents:check -x japiCmp -x checkVersionCatalogCompatibility`
- `./gradlew spotlessApply check -q -x japiCmp -x checkVersionCatalogCompatibility` fails in local Pub/Sub Testcontainers startup for `:test-suite:test` and `:test-suite-groovy:test` (`thekevjames/gcloud-pubsub-emulator:446.0.0`); CloudEvents modules pass before those unrelated failures.

Resolves #1472
