### PR TITLE
Add native metadata for GCP tracing credentials

### DIFF
--- a/gcp-tracing/src/main/resources/META-INF/native-image/io.micronaut/gcp-tracing/reflect-config.json
+++ b/gcp-tracing/src/main/resources/META-INF/native-image/io.micronaut/gcp-tracing/reflect-config.json
@@ -1,0 +1,63 @@
+[
+  {
+    "name": "com.google.auth.oauth2.GoogleCredentials",
+    "methods": [
+      {
+        "name": "getQuotaProjectId",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.auth.oauth2.ServiceAccountCredentials",
+    "allPublicMethods": true
+  },
+  {
+    "name": "com.google.auth.oauth2.ServiceAccountJwtAccessCredentials",
+    "methods": [
+      {
+        "name": "newBuilder",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "com.google.auth.oauth2.ServiceAccountJwtAccessCredentials$Builder",
+    "methods": [
+      {
+        "name": "build",
+        "parameterTypes": []
+      },
+      {
+        "name": "setClientId",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setClientEmail",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setPrivateKey",
+        "parameterTypes": [
+          "java.security.PrivateKey"
+        ]
+      },
+      {
+        "name": "setPrivateKeyId",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "setQuotaProjectId",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      }
+    ]
+  }
+]

--- a/gcp-tracing/src/test/groovy/io/micronaut/gcp/tracing/zipkin/StackdriverConfigurationSpec.groovy
+++ b/gcp-tracing/src/test/groovy/io/micronaut/gcp/tracing/zipkin/StackdriverConfigurationSpec.groovy
@@ -11,6 +11,23 @@ import java.security.PrivateKey
 
 class StackdriverConfigurationSpec extends Specification {
 
+    @Issue("https://github.com/micronaut-projects/micronaut-gcp/issues/761")
+    void "native image metadata includes grpc auth jwt service account methods"() {
+        when:
+        URL metadata = getClass().classLoader.getResource(
+                "META-INF/native-image/io.micronaut/gcp-tracing/reflect-config.json")
+        String reflectConfig = metadata?.text
+
+        then:
+        reflectConfig
+        reflectConfig.contains('"name": "com.google.auth.oauth2.ServiceAccountCredentials"')
+        reflectConfig.contains('"allPublicMethods": true')
+        reflectConfig.contains('"name": "getQuotaProjectId"')
+        reflectConfig.contains('"name": "com.google.auth.oauth2.ServiceAccountJwtAccessCredentials"')
+        reflectConfig.contains('"name": "com.google.auth.oauth2.ServiceAccountJwtAccessCredentials$Builder"')
+        reflectConfig.contains('"name": "setQuotaProjectId"')
+    }
+
     @Issue("https://github.com/micronaut-projects/micronaut-gcp/issues/1045")
     void "application starts successfully with stackdriver and zipkin enabled"() {
         given:


### PR DESCRIPTION
## Summary
- add native-image reflection metadata for the grpc-auth service-account JWT conversion path used by micronaut-gcp-tracing
- cover the packaged metadata from the existing Stackdriver sender configuration spec
- filed upstream reachability metadata request: oracle/graalvm-reachability-metadata#6159

## Verification
- `./gradlew :micronaut-gcp-tracing:check`

Resolves #761
