### PR TITLE
Fix GCF multipart file upload binding

### DIFF
--- a/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/GoogleBinderRegistry.java
+++ b/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/GoogleBinderRegistry.java
@@ -54,5 +54,8 @@ class GoogleBinderRegistry extends DefaultRequestBinderRegistry {
         addArgumentBinder(new GoogleRequestBinder());
         addArgumentBinder(new GoogleResponseBinder());
         addArgumentBinder(new GooglePartBinder<>(messageBodyHandlerRegistry, conversionService));
+        addArgumentBinder(new GoogleCompletedFileUploadBinder());
+        addArgumentBinder(new GoogleStreamingFileUploadBinder());
+        addArgumentBinder(new GoogleBodyAnnotationBinder<>(defaultBodyAnnotationBinder));
     }
 }

--- a/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/GoogleBodyAnnotationBinder.java
+++ b/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/GoogleBodyAnnotationBinder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gcp.function.http;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.bind.binders.BodyArgumentBinder;
+import io.micronaut.http.bind.binders.DefaultBodyAnnotationBinder;
+import io.micronaut.http.multipart.CompletedFileUpload;
+import io.micronaut.http.multipart.StreamingFileUpload;
+
+import java.util.Optional;
+
+/**
+ * Binds completed file uploads from Google multipart parts and delegates other body binding.
+ *
+ * @param <T> The argument type
+ */
+@Internal
+final class GoogleBodyAnnotationBinder<T> implements BodyArgumentBinder<T> {
+
+    private final DefaultBodyAnnotationBinder<T> delegate;
+
+    GoogleBodyAnnotationBinder(DefaultBodyAnnotationBinder<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public BindingResult<T> bind(ArgumentConversionContext<T> context, HttpRequest<?> source) {
+        if (source instanceof GoogleFunctionHttpRequest && isFileUpload(context)) {
+            GoogleFunctionHttpRequest<?> googleRequest = (GoogleFunctionHttpRequest<?>) source;
+            String partName = context.getAnnotationMetadata()
+                    .stringValue(Body.class)
+                    .filter(value -> !value.isEmpty())
+                    .orElse(context.getArgument().getName());
+            Optional<T> fileUpload = Optional.ofNullable(googleRequest.getNativeRequest().getParts().get(partName))
+                    .flatMap(part -> GoogleMultipartSupport.bindFileUpload(context.getArgument(), partName, part, googleRequest.getIoExecutor()));
+            if (fileUpload.isPresent()) {
+                return () -> fileUpload;
+            }
+        }
+        return delegate.bind(context, source);
+    }
+
+    private boolean isFileUpload(ArgumentConversionContext<T> context) {
+        Class<T> type = context.getArgument().getType();
+        return CompletedFileUpload.class.isAssignableFrom(type) || StreamingFileUpload.class.isAssignableFrom(type);
+    }
+}

--- a/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/GoogleCompletedFileUploadBinder.java
+++ b/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/GoogleCompletedFileUploadBinder.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gcp.function.http;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.bind.binders.TypedRequestArgumentBinder;
+import io.micronaut.http.multipart.CompletedFileUpload;
+
+import java.util.Optional;
+
+/**
+ * Binds unannotated completed file upload arguments from Google multipart parts.
+ */
+@Internal
+final class GoogleCompletedFileUploadBinder implements TypedRequestArgumentBinder<CompletedFileUpload> {
+
+    @Override
+    public Argument<CompletedFileUpload> argumentType() {
+        return Argument.of(CompletedFileUpload.class);
+    }
+
+    @Override
+    public BindingResult<CompletedFileUpload> bind(ArgumentConversionContext<CompletedFileUpload> context, HttpRequest<?> source) {
+        if (source instanceof GoogleFunctionHttpRequest) {
+            GoogleFunctionHttpRequest<?> googleRequest = (GoogleFunctionHttpRequest<?>) source;
+            String partName = context.getArgument().getName();
+            return () -> Optional.ofNullable(googleRequest.getNativeRequest().getParts().get(partName))
+                    .flatMap(part -> GoogleMultipartSupport.bindFileUpload(context.getArgument(), partName, part, googleRequest.getIoExecutor()));
+        }
+        return BindingResult.UNSATISFIED;
+    }
+}

--- a/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/GoogleFunctionHttpRequest.java
+++ b/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/GoogleFunctionHttpRequest.java
@@ -98,6 +98,7 @@ final class GoogleFunctionHttpRequest<B> implements
     private final GoogleFunctionHeaders headers;
     private final GoogleFunctionHttpResponse<?> googleResponse;
     private final Supplier<ByteBody> byteBody;
+    private final Executor ioExecutor;
     private MutableHttpParameters httpParameters;
     private MutableConvertibleValues<Object> attributes;
     private B parsedBody;
@@ -132,6 +133,7 @@ final class GoogleFunctionHttpRequest<B> implements
         this.method = method;
         this.headers = new GoogleFunctionHeaders(conversionService);
         this.conversionService = conversionService;
+        this.ioExecutor = ioExecutor;
 
         this.body = SupplierUtil.memoizedNonEmpty(() -> {
             B built = parsedBody != null ? parsedBody :  (B) bodyBuilder.buildBody(this::getInputStream, this);
@@ -189,6 +191,10 @@ final class GoogleFunctionHttpRequest<B> implements
      */
     GoogleFunctionHttpResponse<?> getGoogleResponse() {
         return googleResponse;
+    }
+
+    Executor getIoExecutor() {
+        return ioExecutor;
     }
 
     @NonNull

--- a/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/GoogleMultipartSupport.java
+++ b/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/GoogleMultipartSupport.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gcp.function.http;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.io.buffer.ByteArrayBufferFactory;
+import io.micronaut.core.io.buffer.ReadBufferFactory;
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.body.CloseableByteBody;
+import io.micronaut.http.body.stream.InputStreamByteBody;
+import io.micronaut.http.exceptions.HttpStatusException;
+import io.micronaut.http.multipart.CompletedFileUpload;
+import io.micronaut.http.multipart.FormFieldMetadata;
+import io.micronaut.http.multipart.RawFormField;
+import io.micronaut.http.multipart.StreamingFileUpload;
+
+import com.google.cloud.functions.HttpRequest.HttpPart;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.Executor;
+
+/**
+ * Utilities for adapting Google multipart parts to Micronaut multipart types.
+ */
+@Internal
+final class GoogleMultipartSupport {
+
+    private GoogleMultipartSupport() {
+    }
+
+    static <T> Optional<T> bindFileUpload(Argument<T> argument, String partName, HttpPart part, Executor executor) {
+        Class<T> type = argument.getType();
+        if (CompletedFileUpload.class.isAssignableFrom(type)) {
+            CompletedFileUpload fileUpload = completedFileUpload(partName, part);
+            //noinspection unchecked
+            return (Optional<T>) Optional.of(fileUpload);
+        }
+        if (StreamingFileUpload.class.isAssignableFrom(type)) {
+            StreamingFileUpload fileUpload = streamingFileUpload(partName, part, executor);
+            //noinspection unchecked
+            return (Optional<T>) Optional.of(fileUpload);
+        }
+        return Optional.empty();
+    }
+
+    static CompletedFileUpload completedFileUpload(String partName, HttpPart part) {
+        FormFieldMetadata metadata = formFieldMetadata(partName, part);
+        try (InputStream inputStream = part.getInputStream()) {
+            return CompletedFileUpload.ofMemory(metadata, ReadBufferFactory.getJdkFactory().copyOf(inputStream));
+        } catch (IOException e) {
+            throw unreadablePart(partName, e);
+        }
+    }
+
+    static StreamingFileUpload streamingFileUpload(String partName, HttpPart part, Executor executor) {
+        try {
+            CloseableByteBody byteBody = InputStreamByteBody.create(
+                    part.getInputStream(),
+                    definedSize(part),
+                    executor,
+                    ByteArrayBufferFactory.INSTANCE
+            );
+            return new StreamingFileUpload(new RawFormField(formFieldMetadata(partName, part), byteBody), executor);
+        } catch (IOException e) {
+            throw unreadablePart(partName, e);
+        }
+    }
+
+    private static FormFieldMetadata formFieldMetadata(String partName, HttpPart part) {
+        MediaType contentType = part.getContentType().map(MediaType::of).orElse(null);
+        return new FormFieldMetadata(partName, part.getFileName().orElse(null), contentType);
+    }
+
+    private static OptionalLong definedSize(HttpPart part) {
+        long contentLength = part.getContentLength();
+        return contentLength >= 0 ? OptionalLong.of(contentLength) : OptionalLong.empty();
+    }
+
+    private static HttpStatusException unreadablePart(String partName, IOException e) {
+        return new HttpStatusException(
+                HttpStatus.BAD_REQUEST,
+                "Unable to read part [" + partName + "]: " + e.getMessage()
+        );
+    }
+}

--- a/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/GooglePartBinder.java
+++ b/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/GooglePartBinder.java
@@ -30,6 +30,8 @@ import io.micronaut.http.body.MessageBodyHandlerRegistry;
 import io.micronaut.http.body.MessageBodyReader;
 import io.micronaut.http.codec.CodecException;
 import io.micronaut.http.exceptions.HttpStatusException;
+import io.micronaut.http.multipart.CompletedFileUpload;
+import io.micronaut.http.multipart.StreamingFileUpload;
 import io.micronaut.http.simple.SimpleHttpHeaders;
 
 import java.io.BufferedReader;
@@ -80,6 +82,8 @@ final class GooglePartBinder<T> implements AnnotatedRequestArgumentBinder<Part, 
                 if (HttpPart.class.isAssignableFrom(type)) {
                     //noinspection unchecked
                     return () -> (Optional<T>) Optional.of(part);
+                } else if (CompletedFileUpload.class.isAssignableFrom(type) || StreamingFileUpload.class.isAssignableFrom(type)) {
+                    return () -> GoogleMultipartSupport.bindFileUpload(argument, partName, part, googleRequest.getIoExecutor());
                 } else if (String.class.isAssignableFrom(type)) {
                     try (BufferedReader reader = part.getReader()) {
                         final String content = IOUtils.readText(reader);

--- a/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/GoogleStreamingFileUploadBinder.java
+++ b/gcp-function-http/src/main/java/io/micronaut/gcp/function/http/GoogleStreamingFileUploadBinder.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.gcp.function.http;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.bind.binders.TypedRequestArgumentBinder;
+import io.micronaut.http.multipart.StreamingFileUpload;
+
+import java.util.Optional;
+
+/**
+ * Binds unannotated streaming file upload arguments from Google multipart parts.
+ */
+@Internal
+final class GoogleStreamingFileUploadBinder implements TypedRequestArgumentBinder<StreamingFileUpload> {
+
+    @Override
+    public Argument<StreamingFileUpload> argumentType() {
+        return Argument.of(StreamingFileUpload.class);
+    }
+
+    @Override
+    public BindingResult<StreamingFileUpload> bind(ArgumentConversionContext<StreamingFileUpload> context, HttpRequest<?> source) {
+        if (source instanceof GoogleFunctionHttpRequest) {
+            GoogleFunctionHttpRequest<?> googleRequest = (GoogleFunctionHttpRequest<?>) source;
+            String partName = context.getArgument().getName();
+            return () -> Optional.ofNullable(googleRequest.getNativeRequest().getParts().get(partName))
+                    .flatMap(part -> GoogleMultipartSupport.bindFileUpload(context.getArgument(), partName, part, googleRequest.getIoExecutor()));
+        }
+        return BindingResult.UNSATISFIED;
+    }
+}

--- a/gcp-function-http/src/test/groovy/io/micronaut/gcp/function/http/ParameterBindingSpec.groovy
+++ b/gcp-function-http/src/test/groovy/io/micronaut/gcp/function/http/ParameterBindingSpec.groovy
@@ -237,4 +237,48 @@ class ParameterBindingSpec extends Specification {
         googleResponse.text == 'Good: true'
 
     }
+
+    void "test completed file upload binding for #uri"() {
+        given:
+        HttpRequest googleRequest = new MockGoogleRequest(HttpMethod.POST, uri)
+        googleRequest.parts.put("file", new MockGoogleHttpPart("test.txt", 'Hello upload', "text/plain"))
+        googleRequest.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.MULTIPART_FORM_DATA)
+        HttpResponse googleResponse = new MockGoogleResponse()
+        new HttpFunction()
+                .service(googleRequest, googleResponse)
+
+        expect:
+        googleResponse.statusCode == HttpStatus.OK.code
+        googleResponse.text == 'file:test.txt:text/plain:Hello upload'
+
+        where:
+        uri << [
+                "/parameters/completedFileUpload",
+                "/parameters/completedFileUploadBody",
+                "/parameters/completedFileUploadBodyValue",
+                "/parameters/completedFileUploadPart"
+        ]
+    }
+
+    void "test streaming file upload binding for #uri"() {
+        given:
+        HttpRequest googleRequest = new MockGoogleRequest(HttpMethod.POST, uri)
+        googleRequest.parts.put("file", new MockGoogleHttpPart("test.txt", 'Hello upload', "text/plain"))
+        googleRequest.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.MULTIPART_FORM_DATA)
+        HttpResponse googleResponse = new MockGoogleResponse()
+        new HttpFunction()
+                .service(googleRequest, googleResponse)
+
+        expect:
+        googleResponse.statusCode == HttpStatus.OK.code
+        googleResponse.text == 'file:test.txt:text/plain:12:Hello upload'
+
+        where:
+        uri << [
+                "/parameters/streamingFileUpload",
+                "/parameters/streamingFileUploadBody",
+                "/parameters/streamingFileUploadBodyValue",
+                "/parameters/streamingFileUploadPart"
+        ]
+    }
 }

--- a/gcp-function-http/src/test/java/io/micronaut/gcp/function/http/ParametersController.java
+++ b/gcp-function-http/src/test/java/io/micronaut/gcp/function/http/ParametersController.java
@@ -20,9 +20,12 @@ import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.annotation.Status;
 import io.micronaut.http.cookie.Cookie;
+import io.micronaut.http.multipart.CompletedFileUpload;
+import io.micronaut.http.multipart.StreamingFileUpload;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.InputStream;
 
 
 @Controller("/parameters")
@@ -114,6 +117,57 @@ public class ParametersController {
                 text.equals("Whatever") &&
                 new String(bytes).equals("My Doc") &&
                 IOUtils.readText(raw.getReader()).equals("Another Doc"));
+    }
+
+    @Post(value = "/completedFileUpload", consumes = MediaType.MULTIPART_FORM_DATA, produces = "text/plain")
+    String completedFileUpload(CompletedFileUpload file) throws IOException {
+        return completedFileUploadResult(file);
+    }
+
+    @Post(value = "/completedFileUploadBody", consumes = MediaType.MULTIPART_FORM_DATA, produces = "text/plain")
+    String completedFileUploadBody(@Body CompletedFileUpload file) throws IOException {
+        return completedFileUploadResult(file);
+    }
+
+    @Post(value = "/completedFileUploadBodyValue", consumes = MediaType.MULTIPART_FORM_DATA, produces = "text/plain")
+    String completedFileUploadBodyValue(@Body("file") CompletedFileUpload upload) throws IOException {
+        return completedFileUploadResult(upload);
+    }
+
+    @Post(value = "/completedFileUploadPart", consumes = MediaType.MULTIPART_FORM_DATA, produces = "text/plain")
+    String completedFileUploadPart(@Part("file") CompletedFileUpload upload) throws IOException {
+        return completedFileUploadResult(upload);
+    }
+
+    @Post(value = "/streamingFileUpload", consumes = MediaType.MULTIPART_FORM_DATA, produces = "text/plain")
+    String streamingFileUpload(StreamingFileUpload file) throws IOException {
+        return streamingFileUploadResult(file);
+    }
+
+    @Post(value = "/streamingFileUploadBody", consumes = MediaType.MULTIPART_FORM_DATA, produces = "text/plain")
+    String streamingFileUploadBody(@Body StreamingFileUpload file) throws IOException {
+        return streamingFileUploadResult(file);
+    }
+
+    @Post(value = "/streamingFileUploadBodyValue", consumes = MediaType.MULTIPART_FORM_DATA, produces = "text/plain")
+    String streamingFileUploadBodyValue(@Body("file") StreamingFileUpload upload) throws IOException {
+        return streamingFileUploadResult(upload);
+    }
+
+    @Post(value = "/streamingFileUploadPart", consumes = MediaType.MULTIPART_FORM_DATA, produces = "text/plain")
+    String streamingFileUploadPart(@Part("file") StreamingFileUpload upload) throws IOException {
+        return streamingFileUploadResult(upload);
+    }
+
+    private String completedFileUploadResult(CompletedFileUpload file) throws IOException {
+        return file.getName() + ":" + file.getFilename() + ":" + file.getContentType().map(MediaType::getName).orElse("none") + ":" + new String(file.getBytes());
+    }
+
+    private String streamingFileUploadResult(StreamingFileUpload file) throws IOException {
+        try (StreamingFileUpload upload = file; InputStream inputStream = upload.asInputStream()) {
+            MediaType mediaType = upload.metadata().mediaType();
+            return upload.getName() + ":" + upload.getFilename() + ":" + (mediaType == null ? "none" : mediaType.getName()) + ":" + upload.getDefinedSize().orElse(-1) + ":" + new String(inputStream.readAllBytes());
+        }
     }
 
 }

--- a/src/main/docs/guide/cloudFunction/httpFunctions.adoc
+++ b/src/main/docs/guide/cloudFunction/httpFunctions.adoc
@@ -49,6 +49,23 @@ task('runFunction', type: JavaExec, dependsOn: classes) {
 
 With this in place you can run `./gradlew runFunction` to run the function locally.
 
+=== Multipart Uploads
+
+HTTP functions support binding multipart file parts to Micronaut's upload types.
+For completed uploads, bind the file part to api:http.multipart.CompletedFileUpload[].
+Streaming uploads are also supported with api:http.multipart.StreamingFileUpload[].
+If the parameter name does not match the multipart part name, use `@Body("...")` or `@Part("...")`.
+The lower-level Google Functions API remains available by binding `@Part` to `com.google.cloud.functions.HttpRequest.HttpPart`.
+
+snippet::example.http.MultipartUploadController[tags="imports, clazz", source="main"]
+
+You can test these endpoints locally with `curl`:
+
+[source,bash]
+----
+$ curl -i -F file=@test.txt http://localhost:8080/upload/completed
+----
+
 === Deployment
 
 When deploying the function to Cloud Function you should use the api:gcp.function.http.HttpFunction[] class as the handler reference.
@@ -86,5 +103,3 @@ $ curl -i $YOUR_HTTP_TRIGGER_URL/hello/John
 ```
 
 TIP: See the guide for https://guides.micronaut.io/latest/micronaut-google-cloud-http-function.html[Deploy an HTTP Function to Google Cloud Functions] to learn more.
-
-

--- a/test-suite-groovy/src/main/groovy/example/http/MultipartUploadController.groovy
+++ b/test-suite-groovy/src/main/groovy/example/http/MultipartUploadController.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.http
+//tag::imports[]
+
+import com.google.cloud.functions.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Part
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.multipart.CompletedFileUpload
+import io.micronaut.http.multipart.StreamingFileUpload
+//end::imports[]
+
+//tag::clazz[]
+@Controller("/upload")
+class MultipartUploadController {
+
+    @Post(value = "/completed", consumes = MediaType.MULTIPART_FORM_DATA)
+    HttpResponse<String> uploadCompleted(CompletedFileUpload file) throws IOException {
+        HttpResponse.ok("${file.filename}:${file.bytes.length}")
+    }
+
+    @Post(value = "/completed-named", consumes = MediaType.MULTIPART_FORM_DATA)
+    HttpResponse<String> uploadCompletedNamed(@Body("file") CompletedFileUpload upload) throws IOException {
+        HttpResponse.ok("${upload.filename}:${upload.bytes.length}")
+    }
+
+    @Post(value = "/streaming", consumes = MediaType.MULTIPART_FORM_DATA)
+    HttpResponse<String> uploadStreaming(StreamingFileUpload file) throws IOException {
+        file.asInputStream().withCloseable { inputStream ->
+            HttpResponse.ok("${file.filename}:${inputStream.bytes.length}")
+        }
+    }
+
+    @Post(value = "/raw", consumes = MediaType.MULTIPART_FORM_DATA)
+    HttpResponse<String> uploadRaw(@Part("file") HttpRequest.HttpPart file) {
+        HttpResponse.ok(file.fileName.orElse("unnamed"))
+    }
+}
+//end::clazz[]

--- a/test-suite-kotlin/src/main/kotlin/example/http/MultipartUploadController.kt
+++ b/test-suite-kotlin/src/main/kotlin/example/http/MultipartUploadController.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.http
+//tag::imports[]
+
+import com.google.cloud.functions.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Part
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.multipart.CompletedFileUpload
+import io.micronaut.http.multipart.StreamingFileUpload
+//end::imports[]
+
+//tag::clazz[]
+@Controller("/upload")
+class MultipartUploadController {
+
+    @Post(value = "/completed", consumes = [MediaType.MULTIPART_FORM_DATA])
+    fun uploadCompleted(file: CompletedFileUpload): HttpResponse<String> =
+        HttpResponse.ok("${file.filename}:${file.bytes.size}")
+
+    @Post(value = "/completed-named", consumes = [MediaType.MULTIPART_FORM_DATA])
+    fun uploadCompletedNamed(@Body("file") upload: CompletedFileUpload): HttpResponse<String> =
+        HttpResponse.ok("${upload.filename}:${upload.bytes.size}")
+
+    @Post(value = "/streaming", consumes = [MediaType.MULTIPART_FORM_DATA])
+    fun uploadStreaming(file: StreamingFileUpload): HttpResponse<String> =
+        file.asInputStream().use { inputStream ->
+            HttpResponse.ok("${file.filename}:${inputStream.readBytes().size}")
+        }
+
+    @Post(value = "/raw", consumes = [MediaType.MULTIPART_FORM_DATA])
+    fun uploadRaw(@Part("file") file: HttpRequest.HttpPart): HttpResponse<String> =
+        HttpResponse.ok(file.fileName.orElse("unnamed"))
+}
+//end::clazz[]

--- a/test-suite/src/main/java/example/http/MultipartUploadController.java
+++ b/test-suite/src/main/java/example/http/MultipartUploadController.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.http;
+//tag::imports[]
+
+import com.google.cloud.functions.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Part;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.multipart.CompletedFileUpload;
+import io.micronaut.http.multipart.StreamingFileUpload;
+
+import java.io.IOException;
+import java.io.InputStream;
+//end::imports[]
+
+//tag::clazz[]
+@Controller("/upload")
+public class MultipartUploadController {
+
+    @Post(value = "/completed", consumes = MediaType.MULTIPART_FORM_DATA)
+    HttpResponse<String> uploadCompleted(CompletedFileUpload file) throws IOException {
+        return HttpResponse.ok(file.getFilename() + ":" + file.getBytes().length);
+    }
+
+    @Post(value = "/completed-named", consumes = MediaType.MULTIPART_FORM_DATA)
+    HttpResponse<String> uploadCompletedNamed(@Body("file") CompletedFileUpload upload) throws IOException {
+        return HttpResponse.ok(upload.getFilename() + ":" + upload.getBytes().length);
+    }
+
+    @Post(value = "/streaming", consumes = MediaType.MULTIPART_FORM_DATA)
+    HttpResponse<String> uploadStreaming(StreamingFileUpload file) throws IOException {
+        try (InputStream inputStream = file.asInputStream()) {
+            return HttpResponse.ok(file.getFilename() + ":" + inputStream.readAllBytes().length);
+        }
+    }
+
+    @Post(value = "/raw", consumes = MediaType.MULTIPART_FORM_DATA)
+    HttpResponse<String> uploadRaw(@Part("file") HttpRequest.HttpPart file) {
+        return HttpResponse.ok(file.getFileName().orElse("unnamed"));
+    }
+}
+//end::clazz[]


### PR DESCRIPTION
## Summary
- bind Google Cloud Function multipart parts to Micronaut `CompletedFileUpload` and `StreamingFileUpload`
- support unannotated, `@Body`, `@Body("file")`, and `@Part("file")` upload arguments
- add focused GCF HTTP binding coverage and source-backed multipart upload guide snippets for Java, Groovy, and Kotlin

## Verification
- `./gradlew :micronaut-gcp-function-http:test --tests 'io.micronaut.gcp.function.http.ParameterBindingSpec'`
- `./gradlew :micronaut-gcp-function-http:check -x japiCmp -x checkVersionCatalogCompatibility`
- `./gradlew :test-suite:compileJava :test-suite-groovy:compileGroovy :test-suite-kotlin:compileKotlin publishGuide`
- `./gradlew docs`
- `git diff --cached --check`

Resolves #652
