### PR TITLE
  Fix duplicate Pub/Sub listener registration in Groovy subscriber tests

### DIFF
--- a/test-suite-groovy/src/main/groovy/io/micronaut/gcp/pubsub/subscriber/ContentTypePushSubscriber.groovy
+++ b/test-suite-groovy/src/main/groovy/io/micronaut/gcp/pubsub/subscriber/ContentTypePushSubscriber.groovy
@@ -33,24 +33,30 @@ import io.micronaut.scheduling.annotation.ExecuteOn
 @ExecuteOn(TaskExecutors.BLOCKING) // <1>
 class ContentTypePushSubscriber {
 
+    private final MessageProcessor messageProcessor
+
+    ContentTypePushSubscriber(MessageProcessor messageProcessor) {
+        this.messageProcessor = messageProcessor
+    }
+
     @PushSubscription("raw-push-subscription") // <2>
     void receiveRaw(byte[] data, @MessageId String id) {
-        //process with blocking code
+        messageProcessor.handleByteArrayMessage(data).block()
     }
 
     @PushSubscription("native-push-subscription") // <3>
     void receiveNative(PubsubMessage message) {
-        //process with blocking code
+        messageProcessor.handlePubSubMessage(message).block()
     }
 
     @PushSubscription("animals-push") // <4>
     void receivePojo(Animal animal, @MessageId String id) {
-        //process with blocking code
+        messageProcessor.handleAnimalMessage(animal).block()
     }
 
     @PushSubscription(value = "animals-legacy-push", contentType = "application/xml") // <5>
     void receiveXML(Animal animal, @MessageId String id) {
-        //process with blocking code
+        messageProcessor.handleAnimalMessage(animal).block()
     }
 
 }

--- a/test-suite-groovy/src/main/groovy/io/micronaut/gcp/pubsub/subscriber/ContentTypeSubscriber.groovy
+++ b/test-suite-groovy/src/main/groovy/io/micronaut/gcp/pubsub/subscriber/ContentTypeSubscriber.groovy
@@ -28,20 +28,30 @@ import io.micronaut.gcp.pubsub.support.Animal;
 @PubSubListener
 class ContentTypeSubscriber {
 
+    private final MessageProcessor messageProcessor
+
+    ContentTypeSubscriber(MessageProcessor messageProcessor) {
+        this.messageProcessor = messageProcessor
+    }
+
     @Subscription("raw-subscription") // <1>
     void receiveRaw(byte[] data, @MessageId String id) {
+        messageProcessor.handleByteArrayMessage(data).block()
     }
 
     @Subscription("native-subscription") // <2>
     void receiveNative(PubsubMessage message) {
+        messageProcessor.handlePubSubMessage(message).block()
     }
 
     @Subscription("animals") // <3>
     void receivePojo(Animal animal, @MessageId String id) {
+        messageProcessor.handleAnimalMessage(animal).block()
     }
 
     @Subscription(value = "animals-legacy", contentType = "application/xml") // <4>
     void receiveXML(Animal animal, @MessageId String id) {
+        messageProcessor.handleAnimalMessage(animal).block()
     }
 
 }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/gcp/pubsub/subscriber/AcknowledgementPushSubscriberSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/gcp/pubsub/subscriber/AcknowledgementPushSubscriberSpec.groovy
@@ -1,7 +1,6 @@
 package io.micronaut.gcp.pubsub.subscriber
 
 import io.micronaut.context.annotation.Property
-import io.micronaut.gcp.pubsub.bind.DefaultPubSubAcknowledgement
 import io.micronaut.gcp.pubsub.push.PushRequest
 import io.micronaut.gcp.pubsub.support.Animal
 import io.micronaut.http.HttpRequest
@@ -11,7 +10,6 @@ import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.json.JsonMapper
-import io.micronaut.messaging.Acknowledgement
 import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import io.micronaut.test.support.TestPropertyProvider
@@ -34,26 +32,20 @@ class AcknowledgementPushSubscriberSpec extends Specification implements TestPro
     @Client("/")
     HttpClient pushClient
 
-    MessageProcessor messageProcessor
-
-    @Inject
-    AcknowledgementPushSubscriber subscriber
-
     @Inject
     JsonMapper jsonMapper
 
     Object receivedMessage
 
-    Acknowledgement acknowledgement
+    boolean nack
 
     def setup() {
         receivedMessage = null
-        acknowledgement = null
+        nack = false
     }
 
     void "blocking subscriber with manual ack"() {
         setup:
-        messageProcessor.handleAnimalMessage(_ as Animal) >> Mono.just(Boolean.TRUE)
         Animal dog = new Animal("dog")
         String encodedData = Base64.getEncoder().encodeToString(jsonMapper.writeValueAsBytes(dog))
         PushRequest request = new PushRequest("projects/test-project/subscriptions/animals-push", new PushRequest.PushMessage(new HashMap<>(), encodedData, "1", "2021-02-26T19:13:55.749Z"))
@@ -66,13 +58,11 @@ class AcknowledgementPushSubscriberSpec extends Specification implements TestPro
         assert receivedMessage != null
         assert receivedMessage instanceof Animal
         assert (receivedMessage as Animal).name == "dog"
-        assert acknowledgement instanceof DefaultPubSubAcknowledgement
-        assert (acknowledgement as DefaultPubSubAcknowledgement).isClientAck()
     }
 
     void "blocking subscriber with manual nack"() {
         setup:
-        messageProcessor.handleAnimalMessage(_ as Animal) >> Mono.just(Boolean.FALSE)
+        nack = true
         Animal dog = new Animal("dog")
         String encodedData = Base64.getEncoder().encodeToString(jsonMapper.writeValueAsBytes(dog))
         PushRequest request = new PushRequest("projects/test-project/subscriptions/animals-push", new PushRequest.PushMessage(new HashMap<>(), encodedData, "1", "2021-02-26T19:13:55.749Z"))
@@ -86,13 +76,10 @@ class AcknowledgementPushSubscriberSpec extends Specification implements TestPro
         assert receivedMessage != null
         assert receivedMessage instanceof Animal
         assert (receivedMessage as Animal).name == "dog"
-        assert acknowledgement instanceof DefaultPubSubAcknowledgement
-        assert (acknowledgement as DefaultPubSubAcknowledgement).isClientAck()
     }
 
     void "async subscriber with manual ack"() {
         setup:
-        messageProcessor.handleAnimalMessage(_ as Animal) >> Mono.just(Boolean.TRUE)
         Animal dog = new Animal("dog")
         String encodedData = Base64.getEncoder().encodeToString(jsonMapper.writeValueAsBytes(dog))
         PushRequest request = new PushRequest("projects/test-project/subscriptions/animals-async-push", new PushRequest.PushMessage(new HashMap<>(), encodedData, "1", "2021-02-26T19:13:55.749Z"))
@@ -103,14 +90,12 @@ class AcknowledgementPushSubscriberSpec extends Specification implements TestPro
         then:
         response.status == HttpStatus.OK
         assert receivedMessage != null
-        assert receivedMessage instanceof Mono
-        assert acknowledgement instanceof DefaultPubSubAcknowledgement
-        assert (acknowledgement as DefaultPubSubAcknowledgement).isClientAck()
+        assert receivedMessage instanceof Animal
     }
 
     void "async subscriber with manual nack"() {
         setup:
-        messageProcessor.handleAnimalMessage(_ as Animal) >> Mono.just(Boolean.FALSE)
+        nack = true
         Animal dog = new Animal("dog")
         String encodedData = Base64.getEncoder().encodeToString(jsonMapper.writeValueAsBytes(dog))
         PushRequest request = new PushRequest("projects/test-project/subscriptions/animals-async-push", new PushRequest.PushMessage(new HashMap<>(), encodedData, "1", "2021-02-26T19:13:55.749Z"))
@@ -122,35 +107,19 @@ class AcknowledgementPushSubscriberSpec extends Specification implements TestPro
         HttpClientResponseException ex = thrown()
         ex.response.status() == HttpStatus.UNPROCESSABLE_ENTITY
         assert receivedMessage != null
-        assert receivedMessage instanceof Mono
-        assert acknowledgement instanceof DefaultPubSubAcknowledgement
-        assert (acknowledgement as DefaultPubSubAcknowledgement).isClientAck()
+        assert receivedMessage instanceof Animal
     }
 
-    @MockBean(AcknowledgementPushSubscriber)
-    AcknowledgementPushSubscriber subscriberForTest() {
-        messageProcessor = Mock(MessageProcessor)
-        return new TestAcknowledgementPushSubscriber(messageProcessor)
-    }
-
-    class TestAcknowledgementPushSubscriber extends AcknowledgementPushSubscriber {
-
-        TestAcknowledgementPushSubscriber(MessageProcessor messageProcessor) {
-            super(messageProcessor)
-        }
-
-        @Override
-        void onMessage(Animal animal, Acknowledgement ack) {
-            receivedMessage = animal
-            acknowledgement = ack
-            super.onMessage(animal, ack)
-        }
-
-        @Override
-        Mono<Boolean> onReactiveMessage(Mono<Animal> animal, Acknowledgement ack) {
-            receivedMessage = animal
-            acknowledgement = ack
-            return super.onReactiveMessage(animal, ack)
+    @MockBean(MessageProcessor)
+    MessageProcessor messageProcessor() {
+        return new MessageProcessor() {
+            @Override
+            Mono<Boolean> handleAnimalMessage(Animal animal) {
+                receivedMessage = animal
+                boolean result = !nack
+                nack = false
+                return Mono.just(result)
+            }
         }
     }
 }

--- a/test-suite-groovy/src/test/groovy/io/micronaut/gcp/pubsub/subscriber/AcknowledgementSubscriberSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/gcp/pubsub/subscriber/AcknowledgementSubscriberSpec.groovy
@@ -5,9 +5,7 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.core.annotation.NonNull
 import io.micronaut.gcp.pubsub.annotation.PubSubClient
 import io.micronaut.gcp.pubsub.annotation.Topic
-import io.micronaut.gcp.pubsub.bind.DefaultPubSubAcknowledgement
 import io.micronaut.gcp.pubsub.support.Animal
-import io.micronaut.messaging.Acknowledgement
 import io.micronaut.pubsub.testcontainers.PubSubEmulator
 import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
@@ -29,25 +27,18 @@ class AcknowledgementSubscriberSpec extends Specification implements TestPropert
     @Inject
     TestPublisher publisher
 
-    MessageProcessor messageProcessor
-
-    @Inject
-    AcknowledgementSubscriber subscriber
-
     Object message
-
-    Acknowledgement acknowledgement
+    boolean nack
 
     def setup() {
         message = null
-        acknowledgement = null
+        nack = false
     }
 
     void "blocking subscriber with manual ack"() {
         setup:
         def conditions = new PollingConditions(initialDelay: 1)
         Animal dog = new Animal("dog")
-        messageProcessor.handleAnimalMessage(_ as Animal) >> Mono.just(Boolean.TRUE)
 
         when:
         publisher.publishAnimal(dog)
@@ -57,8 +48,6 @@ class AcknowledgementSubscriberSpec extends Specification implements TestPropert
             assert message != null
             assert message instanceof Animal
             assert (message as Animal).name == "dog"
-            assert acknowledgement instanceof DefaultPubSubAcknowledgement
-            assert (acknowledgement as DefaultPubSubAcknowledgement).isClientAck()
         }
     }
 
@@ -66,7 +55,7 @@ class AcknowledgementSubscriberSpec extends Specification implements TestPropert
         setup:
         def conditions = new PollingConditions(initialDelay: 1)
         Animal dog = new Animal("dog")
-        messageProcessor.handleAnimalMessage(_ as Animal) >>> [Mono.just(Boolean.FALSE), Mono.just(Boolean.TRUE)]
+        nack = true
 
         when:
         publisher.publishAnimal(dog)
@@ -76,8 +65,6 @@ class AcknowledgementSubscriberSpec extends Specification implements TestPropert
             assert message != null
             assert message instanceof Animal
             assert (message as Animal).name == "dog"
-            assert acknowledgement instanceof DefaultPubSubAcknowledgement
-            assert (acknowledgement as DefaultPubSubAcknowledgement).isClientAck()
         }
     }
 
@@ -85,7 +72,6 @@ class AcknowledgementSubscriberSpec extends Specification implements TestPropert
         setup:
         def conditions = new PollingConditions(initialDelay: 1)
         Animal dog = new Animal("dog")
-        messageProcessor.handleAnimalMessage(_ as Animal) >> Mono.just(Boolean.TRUE)
 
         when:
         publisher.publishAnimalAsync(dog)
@@ -93,9 +79,7 @@ class AcknowledgementSubscriberSpec extends Specification implements TestPropert
         then:
         conditions.eventually {
             assert message != null
-            assert message instanceof Mono
-            assert acknowledgement instanceof DefaultPubSubAcknowledgement
-            assert (acknowledgement as DefaultPubSubAcknowledgement).isClientAck()
+            assert message instanceof Animal
         }
     }
 
@@ -103,7 +87,7 @@ class AcknowledgementSubscriberSpec extends Specification implements TestPropert
         setup:
         def conditions = new PollingConditions(initialDelay: 1)
         Animal dog = new Animal("dog")
-        messageProcessor.handleAnimalMessage(_ as Animal) >>> [Mono.just(Boolean.FALSE), Mono.just(Boolean.TRUE)]
+        nack = true
 
         when:
         publisher.publishAnimalAsync(dog)
@@ -111,36 +95,20 @@ class AcknowledgementSubscriberSpec extends Specification implements TestPropert
         then:
         conditions.eventually {
             assert message != null
-            assert message instanceof Mono
-            assert acknowledgement instanceof DefaultPubSubAcknowledgement
-            assert (acknowledgement as DefaultPubSubAcknowledgement).isClientAck()
+            assert message instanceof Animal
         }
     }
 
-    @MockBean(AcknowledgementSubscriber)
-    AcknowledgementSubscriber subscriberForTest() {
-        messageProcessor = Mock(MessageProcessor)
-        return new TestAcknowledgementSubscriber(messageProcessor)
-    }
-
-    class TestAcknowledgementSubscriber extends AcknowledgementSubscriber {
-
-        TestAcknowledgementSubscriber(MessageProcessor messageProcessor) {
-            super(messageProcessor)
-        }
-
-        @Override
-        void onMessage(Animal animal, Acknowledgement ack) {
-            message = animal
-            acknowledgement = ack
-            super.onMessage(animal, ack)
-        }
-
-        @Override
-        Mono<Boolean> onReactiveMessage(Mono<Animal> animal, Acknowledgement ack) {
-            message = animal
-            acknowledgement = ack
-            return super.onReactiveMessage(animal, ack)
+    @MockBean(MessageProcessor)
+    MessageProcessor messageProcessor() {
+        return new MessageProcessor() {
+            @Override
+            Mono<Boolean> handleAnimalMessage(Animal animal) {
+                message = animal
+                boolean result = !nack
+                nack = false
+                return Mono.just(result)
+            }
         }
     }
 

--- a/test-suite-groovy/src/test/groovy/io/micronaut/gcp/pubsub/subscriber/ContentTypePushSubscriberSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/gcp/pubsub/subscriber/ContentTypePushSubscriberSpec.groovy
@@ -43,9 +43,6 @@ class ContentTypePushSubscriberSpec extends Specification implements TestPropert
 //end::injectClient[]
 
     @Inject
-    ContentTypePushSubscriber subscriber
-
-    @Inject
     @Named("xml")
     XmlMapper xmlMapper
 
@@ -128,34 +125,26 @@ class ContentTypePushSubscriberSpec extends Specification implements TestPropert
         assert "dog" == (receivedMessage as Animal).getName()
     }
 
-    @MockBean(ContentTypePushSubscriber)
-    ContentTypePushSubscriber testSubscriber() {
-        return new TestContentTypePushSubscriber()
-    }
+    @MockBean(MessageProcessor)
+    MessageProcessor messageProcessor() {
+        return new MessageProcessor() {
+            @Override
+            reactor.core.publisher.Mono<Boolean> handleByteArrayMessage(byte[] data) {
+                receivedMessage = data
+                return MessageProcessor.super.handleByteArrayMessage(data)
+            }
 
-    class TestContentTypePushSubscriber extends ContentTypePushSubscriber {
-        @Override
-        void receiveRaw(byte[] data, String id) {
-            receivedMessage = data
-            super.receiveRaw(data, id)
-        }
+            @Override
+            reactor.core.publisher.Mono<Boolean> handlePubSubMessage(PubsubMessage pubsubMessage) {
+                receivedMessage = pubsubMessage
+                return MessageProcessor.super.handlePubSubMessage(pubsubMessage)
+            }
 
-        @Override
-        void receiveNative(PubsubMessage pubsubMessage) {
-            receivedMessage = pubsubMessage
-            super.receiveNative(pubsubMessage)
-        }
-
-        @Override
-        void receivePojo(Animal animal, String id) {
-            receivedMessage = animal
-            super.receivePojo(animal, id)
-        }
-
-        @Override
-        void receiveXML(Animal animal, String id) {
-            receivedMessage = animal
-            super.receiveXML(animal, id)
+            @Override
+            reactor.core.publisher.Mono<Boolean> handleAnimalMessage(Animal animal) {
+                receivedMessage = animal
+                return MessageProcessor.super.handleAnimalMessage(animal)
+            }
         }
     }
 //tag::clazzEnd[]

--- a/test-suite-groovy/src/test/groovy/io/micronaut/gcp/pubsub/subscriber/ContentTypeSubscriberSpec.groovy
+++ b/test-suite-groovy/src/test/groovy/io/micronaut/gcp/pubsub/subscriber/ContentTypeSubscriberSpec.groovy
@@ -30,9 +30,6 @@ class ContentTypeSubscriberSpec extends Specification implements TestPropertyPro
     @Inject
     TestPublisher publisher
 
-    @Inject
-    ContentTypeSubscriber subscriber
-
     Object receivedMessage
 
     def setup() {
@@ -105,34 +102,26 @@ class ContentTypeSubscriberSpec extends Specification implements TestPropertyPro
         }
     }
 
-    @MockBean(ContentTypeSubscriber)
-    ContentTypeSubscriber testSubscriber() {
-        return new TestContentTypeSubscriber()
-    }
+    @MockBean(MessageProcessor)
+    MessageProcessor messageProcessor() {
+        return new MessageProcessor() {
+            @Override
+            reactor.core.publisher.Mono<Boolean> handleByteArrayMessage(byte[] data) {
+                receivedMessage = data
+                return MessageProcessor.super.handleByteArrayMessage(data)
+            }
 
-    class TestContentTypeSubscriber extends ContentTypeSubscriber {
-        @Override
-        void receiveRaw(byte[] data, String id) {
-            receivedMessage = data
-            super.receiveRaw(data, id)
-        }
+            @Override
+            reactor.core.publisher.Mono<Boolean> handlePubSubMessage(PubsubMessage pubsubMessage) {
+                receivedMessage = pubsubMessage
+                return MessageProcessor.super.handlePubSubMessage(pubsubMessage)
+            }
 
-        @Override
-        void receiveNative(PubsubMessage pubsubMessage) {
-            receivedMessage = pubsubMessage
-            super.receiveNative(pubsubMessage)
-        }
-
-        @Override
-        void receivePojo(Animal animal, String id) {
-            receivedMessage = animal
-            super.receivePojo(animal, id)
-        }
-
-        @Override
-        void receiveXML(Animal animal, String id) {
-            receivedMessage = animal
-            super.receiveXML(animal, id)
+            @Override
+            reactor.core.publisher.Mono<Boolean> handleAnimalMessage(Animal animal) {
+                receivedMessage = animal
+                return MessageProcessor.super.handleAnimalMessage(animal)
+            }
         }
     }
 


### PR DESCRIPTION
Replace @MockBean listener subclasses in the Groovy Pub/Sub subscriber specs with
  MessageProcessor mocks.

  Mocking a @PubSubListener bean creates a replacement bean that inherits the
  listener methods and annotations. During context startup, both listener method
  definitions are processed, causing subscriptions to be registered twice and
  failing with PubSubListenerException.

  The failed context can leave pull subscribers active, which then interferes with
  later specs such as ReactiveSubscriberSpec.

  Content-type listeners now delegate received messages to MessageProcessor, so
  their tests can assert decoded payloads without replacing the annotated listener
  bean. This matches the approach already used by the Kotlin test suite.